### PR TITLE
Properly parse JSON-API error responses

### DIFF
--- a/src/js/api/static-json.ts
+++ b/src/js/api/static-json.ts
@@ -35,6 +35,7 @@ function callApi(url: string) {
     }))
     .catch(error => ({
       error: error.message || 'An error occurred',
+      details: '',
     }));
 }
 

--- a/src/js/api/types.ts
+++ b/src/js/api/types.ts
@@ -12,7 +12,7 @@ export interface ApiResponse {
   included?: ApiEntity[];
 }
 
-export type ApiPromise = Promise<{ response: ApiResponse; } | { error: string; }>;
+export type ApiPromise = Promise<{ response: ApiResponse; } | { error: string; details: string; }>;
 
 export interface Api {
   fetchActivities: () => ApiPromise;

--- a/src/js/modules/activities/actions.ts
+++ b/src/js/modules/activities/actions.ts
@@ -7,10 +7,11 @@ export const ACTIVITIES = createRequestTypes('ACTIVITIES/ACTIVITIES');
 export const FetchActivities: t.RequestActivitiesActionCreators = {
   request: () => ({ type: ACTIVITIES.REQUEST }),
   success: (response) => ({ type: ACTIVITIES.SUCCESS, response }),
-  failure: (error) => ({
+  failure: (error, details) => ({
     type: ACTIVITIES.FAILURE,
     id: null,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };
@@ -24,10 +25,11 @@ export const ACTIVITIES_FOR_PROJECT = createRequestTypes('ACTIVITIES/ACTIVITIES_
 export const FetchActivitiesForProject: t.RequestActivitiesActionCreators = {
   request: (id) => ({ type: ACTIVITIES_FOR_PROJECT.REQUEST, id }),
   success: (id, response) => ({ type: ACTIVITIES_FOR_PROJECT.SUCCESS, id, response }),
-  failure: (id, error) => ({
+  failure: (id, error, details) => ({
     type: ACTIVITIES_FOR_PROJECT.FAILURE,
     id,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };

--- a/src/js/modules/branches/actions.ts
+++ b/src/js/modules/branches/actions.ts
@@ -7,10 +7,11 @@ export const BRANCH = createRequestTypes('BRANCHES/BRANCH');
 export const FetchBranch: t.RequestBranchActionCreators = {
   request: (id) => ({ type: BRANCH.REQUEST, id }),
   success: (id, response) => ({ type: BRANCH.SUCCESS, id, response }),
-  failure: (id, error) => ({
+  failure: (id, error, details) => ({
     type: BRANCH.FAILURE,
     id,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };

--- a/src/js/modules/commits/actions.ts
+++ b/src/js/modules/commits/actions.ts
@@ -7,7 +7,13 @@ export const COMMIT = createRequestTypes('COMMITS/COMMIT');
 export const FetchCommit: t.RequestCommitActionCreators = {
   request: (id) => ({ type: COMMIT.REQUEST, id }),
   success: (id, response) => ({ type: COMMIT.SUCCESS, id, response }),
-  failure: (id, error) => ({ type: COMMIT.FAILURE, id, error, prettyError: prettyErrorMessage(error) }),
+  failure: (id, error, details) => ({
+    type: COMMIT.FAILURE,
+    id,
+    error,
+    details,
+    prettyError: prettyErrorMessage(error),
+  }),
 };
 
 export const LOAD_COMMIT = 'COMMITS/LOAD_COMMIT';

--- a/src/js/modules/deployments/actions.ts
+++ b/src/js/modules/deployments/actions.ts
@@ -7,10 +7,11 @@ export const DEPLOYMENT = createRequestTypes('DEPLOYMENTS/DEPLOYMENT');
 export const FetchDeployment: t.RequestDeploymentActionCreators = {
   request: (id) => ({ type: DEPLOYMENT.REQUEST, id }),
   success: (id, response) => ({ type: DEPLOYMENT.SUCCESS, id, response }),
-  failure: (id, error) => ({
+  failure: (id, error, details) => ({
     type: DEPLOYMENT.FAILURE,
     id,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };

--- a/src/js/modules/errors/reducer.ts
+++ b/src/js/modules/errors/reducer.ts
@@ -11,7 +11,7 @@ const initialState: t.ErrorState = [];
 const returnFilteredStateIfChanged = (state: t.ErrorState, predicate: (error: t.Error) => boolean): t.ErrorState => {
   const filteredState = state.filter(predicate);
   return filteredState.length !== state.length ? filteredState : state;
-}
+};
 
 const reducer: Reducer<t.ErrorState> = (state = initialState, action: any) => {
   switch (action.type) {

--- a/src/js/modules/errors/types.ts
+++ b/src/js/modules/errors/types.ts
@@ -13,6 +13,8 @@ interface GenericError {
   type: string;
   // The original error message
   error: string;
+  // Detailed error message
+  details: string;
   // The error to display to the user
   prettyError: string;
 }

--- a/src/js/modules/projects/actions.ts
+++ b/src/js/modules/projects/actions.ts
@@ -13,10 +13,11 @@ export const ALL_PROJECTS = createRequestTypes('PROJECTS/ALL_PROJECTS');
 export const FetchAllProjects: t.RequestAllProjectsActionCreators = {
   request: () => ({ type: ALL_PROJECTS.REQUEST }),
   success: (response) => ({ type: ALL_PROJECTS.SUCCESS, response }),
-  failure: (error) => ({
+  failure: (error, details) => ({
     type: ALL_PROJECTS.FAILURE,
     id: null,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };
@@ -32,10 +33,11 @@ export const PROJECT = createRequestTypes('PROJECTS/PROJECT');
 export const FetchProject: t.RequestProjectActionCreators = {
   request: (id) => ({ type: PROJECT.REQUEST, id }),
   success: (id, response) => ({ type: PROJECT.SUCCESS, id, response }),
-  failure: (id, error) => ({
+  failure: (id, error, details) => ({
     type: PROJECT.FAILURE,
     id,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };
@@ -54,9 +56,10 @@ export const SEND_CREATE_PROJECT = createRequestTypes('PROJECTS/SEND_CREATE_PROJ
 export const SendCreateProject: t.SendCreateProjectActionCreators = {
   request: (name, description) => ({ type: SEND_CREATE_PROJECT.REQUEST, name, description }),
   success: (id) => ({ type: SEND_CREATE_PROJECT.SUCCESS, id }),
-  failure: (error) => ({
+  failure: (error, details) => ({
     type: SEND_CREATE_PROJECT.FAILURE,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };
@@ -79,10 +82,11 @@ export const SEND_DELETE_PROJECT = createRequestTypes('PROJECTS/SEND_DELETE_PROJ
 export const SendDeleteProject: t.SendDeleteProjectActionCreators = {
   request: (id) => ({ type: SEND_DELETE_PROJECT.REQUEST, id }),
   success: (id) => ({ type: SEND_DELETE_PROJECT.SUCCESS, id }),
-  failure: (id, error) => ({
+  failure: (id, error, details) => ({
     type: SEND_DELETE_PROJECT.FAILURE,
     id,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };
@@ -94,10 +98,11 @@ export const SEND_EDIT_PROJECT = createRequestTypes('PROJECTS/SEND_EDIT_PROJECT'
 export const SendEditProject: t.SendEditProjectActionCreators = {
   request: (id, newAttributes) => ({ type: SEND_EDIT_PROJECT.REQUEST, id, newAttributes }),
   success: (id) => ({ type: SEND_EDIT_PROJECT.SUCCESS, id }),
-  failure: (id, error) => ({
+  failure: (id, error, details) => ({
     type: SEND_EDIT_PROJECT.FAILURE,
     id,
     error,
+    details,
     prettyError: prettyErrorMessage(error),
   }),
 };

--- a/src/js/sagas/index.ts
+++ b/src/js/sagas/index.ts
@@ -56,7 +56,7 @@ export default function createSagas(api: Api) {
   function* fetchActivities(): IterableIterator<Effect> {
     yield put(Activities.actions.FetchActivities.request());
 
-    const { response, error } = yield call(api.fetchActivities);
+    const { response, error, details } = yield call(api.fetchActivities);
 
     if (response) {
       if (response.included) {
@@ -67,7 +67,7 @@ export default function createSagas(api: Api) {
 
       return true;
     } else {
-      yield put(Activities.actions.FetchActivities.failure(error));
+      yield put(Activities.actions.FetchActivities.failure(error, details));
 
       return false;
     }
@@ -95,7 +95,7 @@ export default function createSagas(api: Api) {
   function* fetchActivitiesForProject(id: string): IterableIterator<Effect> {
     yield put(Activities.actions.FetchActivitiesForProject.request(id));
 
-    const { response, error } = yield call(api.fetchActivitiesForProject, id);
+    const { response, error, details } = yield call(api.fetchActivitiesForProject, id);
 
     if (response) {
       if (response.included) {
@@ -106,7 +106,7 @@ export default function createSagas(api: Api) {
 
       return true;
     } else {
-      yield put(Activities.actions.FetchActivitiesForProject.failure(id, error));
+      yield put(Activities.actions.FetchActivitiesForProject.failure(id, error, details));
 
       return false;
     }
@@ -123,7 +123,7 @@ export default function createSagas(api: Api) {
   function* fetchAllProjects(): IterableIterator<Effect> {
     yield put(Projects.actions.FetchAllProjects.request());
 
-    const { response, error } = yield call(api.fetchAllProjects);
+    const { response, error, details } = yield call(api.fetchAllProjects);
 
     if (response) {
       if (response.included) {
@@ -134,7 +134,7 @@ export default function createSagas(api: Api) {
 
       return true;
     } else {
-      yield put(Projects.actions.FetchAllProjects.failure(error));
+      yield put(Projects.actions.FetchAllProjects.failure(error, details));
 
       return false;
     }
@@ -231,7 +231,7 @@ export default function createSagas(api: Api) {
 
     yield put(Projects.actions.SendCreateProject.request(name, description));
 
-    const { response, error } = yield call(api.createProject, name, description);
+    const { response, error, details } = yield call(api.createProject, name, description);
 
     if (response) {
       if (response.included) {
@@ -249,7 +249,7 @@ export default function createSagas(api: Api) {
       return true;
     } else {
       // Notify form that creation failed
-      yield put(Projects.actions.SendCreateProject.failure(error));
+      yield put(Projects.actions.SendCreateProject.failure(error, details));
 
       return false;
     }
@@ -261,7 +261,7 @@ export default function createSagas(api: Api) {
 
     yield put(Projects.actions.SendDeleteProject.request(id));
 
-    const { response, error } = yield call(api.deleteProject, id);
+    const { response, error, details } = yield call(api.deleteProject, id);
 
     if (response) {
       yield call(resolve);
@@ -270,7 +270,7 @@ export default function createSagas(api: Api) {
       return true;
     } else {
       yield call(reject);
-      yield put(Projects.actions.SendDeleteProject.failure(id, error));
+      yield put(Projects.actions.SendDeleteProject.failure(id, error, details));
 
       return false;
     }
@@ -284,7 +284,7 @@ export default function createSagas(api: Api) {
 
     yield put(Projects.actions.SendEditProject.request(id));
 
-    const { response, error } = yield call(api.editProject, id, { name, description });
+    const { response, error, details } = yield call(api.editProject, id, { name, description });
 
     if (response) {
       // Store edited project
@@ -295,7 +295,7 @@ export default function createSagas(api: Api) {
       return true;
     } else {
       // Notify form that creation failed
-      yield put(Projects.actions.SendEditProject.failure(id, error));
+      yield put(Projects.actions.SendEditProject.failure(id, error, details));
 
       return false;
     }

--- a/test/reducers.spec.ts
+++ b/test/reducers.spec.ts
@@ -513,6 +513,7 @@ describe('reducers', () => {
         type: Projects.actions.ALL_PROJECTS.FAILURE,
         id: null,
         error: 'projects fetch error',
+        details: 'detailed fetch error',
         prettyError: 'pretty error',
       };
 
@@ -529,6 +530,7 @@ describe('reducers', () => {
           id: null,
           type: Activities.actions.ACTIVITIES.FAILURE,
           error: 'foobar error',
+          details: 'detailed foobar error',
           prettyError: 'pretty foobar error',
         },
       ];
@@ -537,6 +539,7 @@ describe('reducers', () => {
         type: Projects.actions.ALL_PROJECTS.FAILURE,
         id: null,
         error: 'projects fetch error',
+        details: 'detailed fetch error',
         prettyError: 'pretty error',
       };
 
@@ -554,6 +557,7 @@ describe('reducers', () => {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'projects fetch error',
+          details: 'detailed fetch error',
           prettyError: 'pretty error',
         },
       ];
@@ -562,6 +566,7 @@ describe('reducers', () => {
         id: null,
         type: Activities.actions.ACTIVITIES.FAILURE,
         error: 'foobar error',
+        details: 'detailed foobar error',
         prettyError: 'pretty foobar error',
       };
 
@@ -579,18 +584,21 @@ describe('reducers', () => {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'projects fetch error',
+          details: 'detailed fetch error',
           prettyError: 'pretty error',
         },
         {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'another projects fetch error',
+          details: 'another detailed error',
           prettyError: 'another pretty error',
         },
         {
           id: null,
           type: Activities.actions.ACTIVITIES.FAILURE,
           error: 'foobar error',
+          details: 'detailed foobar error',
           prettyError: 'pretty foobar error',
         },
       ];
@@ -613,18 +621,21 @@ describe('reducers', () => {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'projects fetch error',
+          details: 'detailed fetch error',
           prettyError: 'pretty error',
         },
         {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'another projects fetch error',
+          details: 'another detailed error',
           prettyError: 'another pretty error',
         },
         {
           id: null,
           type: Activities.actions.ACTIVITIES.FAILURE,
           error: 'foobar error',
+          details: 'detailed foobar error',
           prettyError: 'pretty foobar error',
         },
       ];
@@ -647,6 +658,7 @@ describe('reducers', () => {
         type: Projects.actions.SEND_DELETE_PROJECT.FAILURE,
         id: 'foo',
         error: 'failed',
+        details: 'detailed error\nhere',
         prettyError: 'failed',
       };
       const expectedState = [action];
@@ -661,6 +673,7 @@ describe('reducers', () => {
         type: Projects.actions.SEND_DELETE_PROJECT.FAILURE,
         id: 'foo',
         error: 'failed',
+        details: 'detailed error\nhere',
         prettyError: 'failed',
       }];
       const action = {
@@ -680,30 +693,35 @@ describe('reducers', () => {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'projects fetch error',
+          details: 'detailed fetch error',
           prettyError: 'pretty error',
         },
         {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'another projects fetch error',
+          details: 'another detailed error',
           prettyError: 'another pretty error',
         },
         {
           id: null,
           type: Activities.actions.ACTIVITIES.FAILURE,
           error: 'foobar error',
+          details: 'detailed foobar error',
           prettyError: 'pretty foobar error',
         },
         {
           type: Projects.actions.SEND_DELETE_PROJECT.FAILURE,
           id: 'foo',
           error: 'failed',
+          details: 'detailed error\nhere',
           prettyError: 'failed',
         },
         {
           type: Projects.actions.SEND_DELETE_PROJECT.FAILURE,
           id: 'bar',
           error: 'failed',
+          details: 'detailed error\nhere',
           prettyError: 'failed',
         },
       ];
@@ -715,18 +733,21 @@ describe('reducers', () => {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'projects fetch error',
+          details: 'detailed fetch error',
           prettyError: 'pretty error',
         },
         {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'another projects fetch error',
+          details: 'another detailed error',
           prettyError: 'another pretty error',
         },
         {
           id: null,
           type: Activities.actions.ACTIVITIES.FAILURE,
           error: 'foobar error',
+          details: 'detailed foobar error',
           prettyError: 'pretty foobar error',
         },
       ];
@@ -742,18 +763,21 @@ describe('reducers', () => {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'projects fetch error',
+          details: 'detailed fetch error',
           prettyError: 'pretty error',
         },
         {
           type: Projects.actions.ALL_PROJECTS.FAILURE,
           id: null,
           error: 'another projects fetch error',
+          details: 'another detailed error',
           prettyError: 'another pretty error',
         },
         {
           id: null,
           type: Activities.actions.ACTIVITIES.FAILURE,
           error: 'foobar error',
+          details: 'detailed foobar error',
           prettyError: 'pretty foobar error',
         },
       ];
@@ -978,6 +1002,7 @@ describe('reducers', () => {
       id: '1',
       type: Branches.actions.BRANCH.FAILURE,
       error: 'Error message in testing',
+      details: 'Detailed message in testing',
       prettyError: 'Pretty error message in testing',
     };
 
@@ -1124,6 +1149,7 @@ describe('reducers', () => {
       id: '2543452',
       type: Commits.actions.COMMIT.FAILURE,
       error: 'Error message in testing',
+      details: 'Detailed message in testing',
       prettyError: 'Pretty error message in testing',
     };
 
@@ -1216,6 +1242,7 @@ describe('reducers', () => {
       id: '7',
       type: Deployments.actions.DEPLOYMENT.FAILURE,
       error: 'Error message in testing',
+      details: 'Detailed message in testing',
       prettyError: 'Pretty error message in testing',
     };
 
@@ -1334,6 +1361,7 @@ describe('reducers', () => {
       id: '1',
       type: Projects.actions.PROJECT.FAILURE,
       error: 'Error message in testing',
+      details: 'Detailed message in testing',
       prettyError: 'Pretty error message in testing',
     };
 


### PR DESCRIPTION
Make the default error message a summary of the title attributes, and concatenate the detail attributes into a details attribute. We will, of course, need to tweak what to show the user, but at least we have access to more detailed error information now.
