### PR TITLE
Simplify request action creator typings

### DIFF
--- a/src/js/modules/activities/reducer.ts
+++ b/src/js/modules/activities/reducer.ts
@@ -1,6 +1,8 @@
 import * as moment from 'moment';
 import { Reducer } from 'redux';
 
+import { RequestFetchSuccessAction } from '../types';
+
 import { ACTIVITIES, ACTIVITIES_FOR_PROJECT, STORE_ACTIVITIES } from './actions';
 import * as t from './types';
 
@@ -44,7 +46,7 @@ const reducer: Reducer<t.ActivityState> = (state: t.ActivityState = initialState
   switch (action.type) {
     case ACTIVITIES_FOR_PROJECT.SUCCESS:
     case ACTIVITIES.SUCCESS:
-      const activitiesResponse = (<t.RequestActivitiesSuccessAction> action).response;
+      const activitiesResponse = (<RequestFetchSuccessAction<t.ResponseActivityElement[]>> action).response;
       if (activitiesResponse && activitiesResponse.length > 0) {
         return Object.assign({}, state, responseToStateShape(activitiesResponse));
       }

--- a/src/js/modules/activities/types.ts
+++ b/src/js/modules/activities/types.ts
@@ -1,7 +1,6 @@
 import { Action } from 'redux';
 
-import { FetchCollectionError } from '../errors';
-import { RequestFetchActionCreators, RequestFetchCollectionActionCreators } from '../types';
+import { RequestFetchCollectionActionCreators, RequestFetchSpecificCollectionActionCreators } from '../types';
 
 // State
 export enum ActivityType {
@@ -27,44 +26,15 @@ export interface ActivityState {
 export interface LoadActivitiesAction extends Action {
 
 }
-
-export interface RequestActivitiesRequestAction extends Action {
-
-}
-
-export interface RequestActivitiesSuccessAction extends Action {
-  response: ResponseActivityElement[];
-}
-
 export type RequestActivitiesActionCreators =
-  RequestFetchCollectionActionCreators<
-    RequestActivitiesRequestAction,
-    ResponseActivityElement[],
-    RequestActivitiesSuccessAction,
-    FetchCollectionError
-  >;
+  RequestFetchCollectionActionCreators<ResponseActivityElement[]>;
 
 // ACTIVITIES_FOR_PROJECT
 export interface LoadActivitiesForProjectAction extends Action {
   id: string;
 }
-
-export interface RequestActivitiesForProjectRequestAction extends Action {
-  id: string;
-}
-
-export interface RequestActivitiesForProjectSuccessAction extends Action {
-  id: string;
-  response: ResponseActivityElement[];
-}
-
 export type RequestActivitiesForProjectActionCreators =
-  RequestFetchActionCreators<
-    RequestActivitiesForProjectRequestAction,
-    ResponseActivityElement[],
-    RequestActivitiesForProjectSuccessAction,
-    FetchCollectionError
-  >;
+  RequestFetchSpecificCollectionActionCreators<ResponseActivityElement[]>;
 
 // STORE_PROJECTS
 export interface StoreActivitiesAction extends Action {

--- a/src/js/modules/branches/reducer.ts
+++ b/src/js/modules/branches/reducer.ts
@@ -1,6 +1,7 @@
 import { Reducer } from 'redux';
 
 import { FetchError, isFetchError } from '../errors';
+import { RequestFetchSuccessAction } from '../types';
 
 import { BRANCH, STORE_BRANCHES } from './actions';
 import * as t from './types';
@@ -40,7 +41,7 @@ const responseToStateShape = (branches: t.ApiResponse) => {
 const reducer: Reducer<t.BranchState> = (state = initialState, action: any) => {
   switch (action.type) {
     case BRANCH.SUCCESS:
-      const branchResonse = (<t.RequestBranchSuccessAction> action).response;
+      const branchResonse = (<RequestFetchSuccessAction<t.ResponseBranchElement>> action).response;
       if (branchResonse) {
         return Object.assign({}, state, responseToStateShape([branchResonse]));
       }

--- a/src/js/modules/branches/types.ts
+++ b/src/js/modules/branches/types.ts
@@ -22,24 +22,7 @@ export interface BranchState {
 export interface LoadBranchAction extends Action {
   id: string;
 }
-
-// BRANCH
-export interface RequestBranchRequestAction extends Action {
-  id: string;
-}
-
-export interface RequestBranchSuccessAction extends Action {
-  id: string;
-  response: ResponseBranchElement;
-}
-
-export type RequestBranchActionCreators =
-  RequestFetchActionCreators<
-    RequestBranchRequestAction,
-    ResponseBranchElement,
-    RequestBranchSuccessAction,
-    FetchError
-  >;
+export type RequestBranchActionCreators = RequestFetchActionCreators<ResponseBranchElement>;
 
 // STORE_BRANCHES
 export interface StoreBranchesAction extends Action {

--- a/src/js/modules/commits/reducer.ts
+++ b/src/js/modules/commits/reducer.ts
@@ -2,6 +2,7 @@ import * as moment from 'moment';
 import { Reducer } from 'redux';
 
 import { FetchError, isFetchError } from '../errors';
+import { RequestFetchSuccessAction } from '../types';
 
 import { COMMIT, STORE_COMMITS } from './actions';
 import * as t from './types';
@@ -51,7 +52,7 @@ const responseToStateShape = (commits: t.ApiResponse) => {
 const reducer: Reducer<t.CommitState> = (state = initialState, action: any) => {
   switch (action.type) {
     case COMMIT.SUCCESS:
-      const commitResonse = (<t.RequestCommitSuccessAction> action).response;
+      const commitResonse = (<RequestFetchSuccessAction<t.ResponseCommitElement>> action).response;
       if (commitResonse) {
         return Object.assign({}, state, responseToStateShape([commitResonse]));
       }

--- a/src/js/modules/commits/types.ts
+++ b/src/js/modules/commits/types.ts
@@ -23,24 +23,7 @@ export interface CommitState {
 export interface LoadCommitAction extends Action {
   id: string;
 }
-
-// COMMIT
-export interface RequestCommitRequestAction extends Action {
-  id: string;
-}
-
-export interface RequestCommitSuccessAction extends Action {
-  id: string;
-  response: ResponseCommitElement;
-}
-
-export type RequestCommitActionCreators =
-  RequestFetchActionCreators<
-    RequestCommitRequestAction,
-    ResponseCommitElement,
-    RequestCommitSuccessAction,
-    FetchError
-  >;
+export type RequestCommitActionCreators = RequestFetchActionCreators<ResponseCommitElement>;
 
 // STORE_COMMITS
 export interface StoreCommitsAction extends Action {

--- a/src/js/modules/deployments/reducer.ts
+++ b/src/js/modules/deployments/reducer.ts
@@ -2,6 +2,7 @@ import * as moment from 'moment';
 import { Reducer } from 'redux';
 
 import { FetchError, isFetchError } from '../errors';
+import { RequestFetchSuccessAction } from '../types';
 
 import { DEPLOYMENT, STORE_DEPLOYMENTS } from './actions';
 import * as t from './types';
@@ -38,7 +39,7 @@ const responseToStateShape = (deployments: t.ApiResponse) => {
 const reducer: Reducer<t.DeploymentState> = (state = initialState, action: any) => {
   switch (action.type) {
     case DEPLOYMENT.SUCCESS:
-      const deploymentResponse = (<t.RequestDeploymentSuccessAction> action).response;
+      const deploymentResponse = (<RequestFetchSuccessAction<t.ResponseDeploymentElement>> action).response;
       if (deploymentResponse) {
         return Object.assign({}, state, responseToStateShape([deploymentResponse]));
       }

--- a/src/js/modules/deployments/types.ts
+++ b/src/js/modules/deployments/types.ts
@@ -28,24 +28,7 @@ export interface DeploymentState {
 export interface LoadDeploymentAction extends Action {
   id: string;
 }
-
-// DEPLOYMENT
-export interface RequestDeploymentRequestAction extends Action {
-  id: string;
-}
-
-export interface RequestDeploymentSuccessAction extends Action {
-  id: string;
-  response: ResponseDeploymentElement;
-}
-
-export type RequestDeploymentActionCreators =
-  RequestFetchActionCreators<
-    RequestDeploymentRequestAction,
-    ResponseDeploymentElement,
-    RequestDeploymentSuccessAction,
-    FetchError
-  >;
+export type RequestDeploymentActionCreators = RequestFetchActionCreators<ResponseDeploymentElement>;
 
 // STORE_DEPLOYMENTS
 export interface StoreDeploymentsAction extends Action {

--- a/src/js/modules/projects/reducer.ts
+++ b/src/js/modules/projects/reducer.ts
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import { Reducer } from 'redux';
 
 import { FetchError, isFetchError } from '../errors';
+import { RequestDeleteSuccessAction, RequestFetchCollectionSuccessAction, RequestFetchSuccessAction } from '../types';
 
 import { ALL_PROJECTS, PROJECT, SEND_DELETE_PROJECT, STORE_PROJECTS } from './actions';
 import * as t from './types';
@@ -42,14 +43,14 @@ const responseToStateShape = (projects: t.ApiResponse) => {
 const reducer: Reducer<t.ProjectState> = (state = initialState, action: any) => {
   switch (action.type) {
     case ALL_PROJECTS.SUCCESS:
-      const projectsResponse = (<t.RequestAllProjectsSuccessAction> action).response;
+      const projectsResponse = (<RequestFetchCollectionSuccessAction<t.ResponseProjectElement[]>> action).response;
       if (projectsResponse && projectsResponse.length > 0) {
         return Object.assign({}, state, responseToStateShape(projectsResponse));
       }
 
       return state;
     case PROJECT.SUCCESS:
-      const projectResponse = (<t.RequestProjectSuccessAction> action).response;
+      const projectResponse = (<RequestFetchSuccessAction<t.ResponseProjectElement>> action).response;
       if (projectResponse) {
         return Object.assign({}, state, responseToStateShape([projectResponse]));
       }
@@ -66,7 +67,7 @@ const reducer: Reducer<t.ProjectState> = (state = initialState, action: any) => 
       console.log('Error: fetching failed! Not replacing existing entity.'); // tslint:disable-line:no-console
       return state;
     case SEND_DELETE_PROJECT.SUCCESS:
-      const { id: idToDelete } = (<t.SendDeleteProjectSuccessAction> action);
+      const { id: idToDelete } = (<RequestDeleteSuccessAction> action);
       if (state[idToDelete]) {
         return omit<t.ProjectState, t.ProjectState>(state, idToDelete);
       }

--- a/src/js/modules/projects/types.ts
+++ b/src/js/modules/projects/types.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { CreateError, DeleteError, EditError, FetchCollectionError, FetchError } from '../errors';
+import { FetchError } from '../errors';
 import {
   ApiUser,
   RequestCreateActionCreators,
@@ -26,84 +26,25 @@ export interface ProjectState {
 
 // Actions
 // LOAD_ALL_PROJECTS
-export interface LoadAllProjectsAction extends Action {
-
-}
-
-// ALL_PROJECTS
-export interface RequestAllProjectsRequestAction extends Action {
-
-}
-
-export interface RequestAllProjectsSuccessAction extends Action {
-  response: ResponseProjectElement[];
-}
-
-export type RequestAllProjectsActionCreators =
-  RequestFetchCollectionActionCreators<
-    RequestAllProjectsRequestAction,
-    ResponseProjectElement[],
-    RequestAllProjectsSuccessAction,
-    FetchCollectionError
-  >;
+export interface LoadAllProjectsAction extends Action {}
+export type RequestAllProjectsActionCreators = RequestFetchCollectionActionCreators<ResponseProjectElement[]>;
 
 // LOAD_PROJECT
 export interface LoadProjectAction extends Action {
   id: string;
 }
-
-// PROJECT
-export interface RequestProjectRequestAction extends Action {
-  id: string;
-}
-
-export interface RequestProjectSuccessAction extends Action {
-  id: string;
-  response: ResponseProjectElement;
-}
-
-export type RequestProjectActionCreators =
-  RequestFetchActionCreators<
-    RequestProjectRequestAction,
-    ResponseProjectElement,
-    RequestProjectSuccessAction,
-    FetchError
-  >;
+export type RequestProjectActionCreators = RequestFetchActionCreators<ResponseProjectElement>;
 
 // STORE_PROJECTS
 export interface StoreProjectsAction extends Action {
   entities: ResponseProjectElement[];
 }
 
-// SEND_CREATE_PROJECT
-export interface SendCreateProjectRequestAction extends Action {
-  name: string;
-}
+// CREATE_PROJECT
+export type SendCreateProjectActionCreators = RequestCreateActionCreators;
 
-export interface SendCreateProjectSuccessAction extends Action {
-  id: string;
-}
-
-export type SendCreateProjectActionCreators = RequestCreateActionCreators<
-  SendCreateProjectRequestAction,
-  SendCreateProjectSuccessAction,
-  CreateError
->;
-
-// SEND_EDIT_PROJECT
-export interface SendEditProjectRequestAction extends Action {
-  id: string;
-}
-
-export interface SendEditProjectSuccessAction extends Action {
-  id: string;
-}
-
-export type SendEditProjectActionCreators = RequestEditActionCreators<
-  SendEditProjectRequestAction,
-  SendEditProjectSuccessAction,
-  EditError
->;
+// EDIT_PROJECT
+export type SendEditProjectActionCreators = RequestEditActionCreators;
 
 // DELETE_PROJECT
 export interface DeleteProjectAction extends Action {
@@ -111,21 +52,7 @@ export interface DeleteProjectAction extends Action {
   resolve: () => void;
   reject: () => void;
 }
-
-// SEND_DELETE_PROJECT
-export interface SendDeleteProjectRequestAction extends Action {
-  id: string;
-}
-
-export interface SendDeleteProjectSuccessAction extends Action {
-  id: string;
-}
-
-export type SendDeleteProjectActionCreators = RequestDeleteActionCreators<
-  SendDeleteProjectRequestAction,
-  SendDeleteProjectSuccessAction,
-  DeleteError
->;
+export type SendDeleteProjectActionCreators = RequestDeleteActionCreators;
 
 // API response
 interface ResponseBranchReference {

--- a/src/js/modules/types.d.ts
+++ b/src/js/modules/types.d.ts
@@ -1,4 +1,5 @@
 import { Action } from 'redux';
+import { CreateError, DeleteError, EditError, FetchError, FetchCollectionError } from './errors'
 
 export interface User {
   name?: string;
@@ -12,32 +13,93 @@ export interface ApiUser {
   timestamp: string;
 }
 
-export interface RequestFetchActionCreators<R extends Action, ResponseEntity, S extends Action, F extends Action> {
-  request: (id: string) => R;
-  success: (id: string, response: ResponseEntity) => S;
-  failure: (id: string, error: string, details?: string) => F;
+// Fetch a single entity
+interface RequestFetchRequestAction extends Action {
+  id: string;
 }
 
-export interface RequestFetchCollectionActionCreators<R extends Action, ResponseEntity, S extends Action, F extends Action> {
-  request: () => R;
-  success: (response: ResponseEntity) => S;
-  failure: (error: string, details?: string) => F;
+interface RequestFetchSuccessAction<ResponseType> extends Action {
+  id: string;
+  response: ResponseType;
 }
 
-export interface RequestCreateActionCreators<R extends Action, S extends Action, F extends Action> {
-  request: (name: string) => R;
-  success: (id: string) => S;
-  failure: (error: string, details?: string) => F;
+export interface RequestFetchActionCreators<ResponseEntity> {
+  request: (id: string) => RequestFetchRequestAction;
+  success: (id: string, response: ResponseEntity) => RequestFetchSuccessAction<ResponseEntity>;
+  failure: (id: string, error: string, details?: string) => FetchError;
 }
 
-export interface RequestEditActionCreators<R extends Action, S extends Action, F extends Action> {
-  request: (id: string) => R;
-  success: (id: string) => S;
-  failure: (id: string, error: string, details?: string) => F;
+// Fetch a collection
+interface RequestFetchCollectionRequestAction extends Action {
+
 }
 
-export interface RequestDeleteActionCreators<R extends Action, S extends Action, F extends Action> {
-  request: (id: string) => R;
-  success: (id: string) => S;
-  failure: (id: string, error: string, details?: string) => F;
+interface RequestFetchCollectionSuccessAction<ResponseType> extends Action {
+  response: ResponseType;
+}
+
+export interface RequestFetchCollectionActionCreators<ResponseEntity> {
+  request: () => RequestFetchCollectionRequestAction;
+  success: (response: ResponseEntity) => RequestFetchCollectionSuccessAction<ResponseEntity>;
+  failure: (error: string, details?: string) => FetchCollectionError;
+}
+
+// Fetch a specific collection (e.g. branches of project)
+interface RequestFetchSpecificCollectionRequestAction extends Action {
+  id: string;
+}
+
+interface RequestFetchSpecificCollectionSuccessAction<ResponseType> extends Action {
+  response: ResponseType;
+}
+
+export interface RequestFetchSpecificCollectionActionCreators<ResponseEntity> {
+  request: (id: string) => RequestFetchSpecificCollectionRequestAction;
+  success: (id: string, response: ResponseEntity) => RequestFetchSpecificCollectionSuccessAction<ResponseEntity>;
+  failure: (id: string, error: string, details?: string) => FetchCollectionError;
+}
+
+// Create an entity
+interface RequestCreateRequestAction extends Action {
+  name: string;
+}
+
+interface RequestCreateSuccessAction extends Action {
+  id: string;
+}
+
+export interface RequestCreateActionCreators {
+  request: (name: string) => RequestCreateRequestAction;
+  success: (id: string) => RequestCreateSuccessAction;
+  failure: (error: string, details?: string) => CreateError;
+}
+
+// Edit an entity
+interface RequestEditRequestAction extends Action {
+  id: string;
+}
+
+interface RequestEditSuccessAction extends Action {
+  id: string;
+}
+
+export interface RequestEditActionCreators {
+  request: (id: string) => RequestEditRequestAction;
+  success: (id: string) => RequestEditSuccessAction;
+  failure: (id: string, error: string, details?: string) => EditError;
+}
+
+// Delete an entity
+interface RequestDeleteRequestAction extends Action {
+  id: string;
+}
+
+interface RequestDeleteSuccessAction extends Action {
+  id: string;
+}
+
+export interface RequestDeleteActionCreators {
+  request: (id: string) => RequestDeleteRequestAction;
+  success: (id: string) => RequestDeleteSuccessAction;
+  failure: (id: string, error: string, details?: string) => DeleteError;
 }

--- a/src/js/sagas/index.ts
+++ b/src/js/sagas/index.ts
@@ -9,7 +9,7 @@ import Branches, { Branch } from '../modules/branches';
 import Commits, { Commit } from '../modules/commits';
 import Deployments, { Deployment } from '../modules/deployments';
 import { onSubmitActions, FORM_SUBMIT } from '../modules/forms';
-import Projects, { Project, LoadAllProjectsAction, DeleteProjectAction } from '../modules/projects';
+import Projects, { Project, DeleteProjectAction } from '../modules/projects';
 
 // Loaders check whether an entity exists. If not, fetch it with a fetcher.
 // Afterwards, the loader also ensures that other needed data exists.

--- a/src/js/sagas/utils.ts
+++ b/src/js/sagas/utils.ts
@@ -1,4 +1,4 @@
-import { Action, ActionCreator } from 'redux';
+import { ActionCreator } from 'redux';
 import { Effect, call, fork, put, select } from 'redux-saga/effects';
 
 import { ApiEntity, ApiEntityTypeString, ApiPromise } from '../api/types';
@@ -37,8 +37,8 @@ export const createLoader = (
   };
 };
 
-export const createFetcher = <R extends Action, ResponseEntity, S extends Action, F extends Action>(
-  requestActionCreators: RequestFetchActionCreators<R, ResponseEntity, S, F>,
+export const createFetcher = <ResponseEntity>(
+  requestActionCreators: RequestFetchActionCreators<ResponseEntity>,
   apiFetchFunction: (id: string) => ApiPromise
 ) => {
   return function* (id: string): IterableIterator<Effect> { // tslint:disable-line:only-arrow-functions


### PR DESCRIPTION
All the fetch entity, fetch collection, etc. requests actions had the same shape, but were defined separately for each module. Only the response data shape differed. Now moved the definitions to the common types.d.ts.
