### PR TITLE
Show Project View content even if branches haven't been loaded yet

### DIFF
--- a/src/js/components/project-view/index.tsx
+++ b/src/js/components/project-view/index.tsx
@@ -55,7 +55,7 @@ class ProjectView extends React.Component<PassedProps & GeneratedStateProps & Ge
   public render() {
     const { project, branches } = this.props;
 
-    if (!project || !branches) {
+    if (!project) {
       return <LoadingIcon className={styles.loading} center />;
     }
 
@@ -84,7 +84,7 @@ class ProjectView extends React.Component<PassedProps & GeneratedStateProps & Ge
     if (show === 'all') {
       return (
         <div>
-          <ProjectBranches project={project} branches={branches!} showAll />
+          <ProjectBranches project={project} branches={branches} showAll />
         </div>
       );
     }
@@ -93,7 +93,7 @@ class ProjectView extends React.Component<PassedProps & GeneratedStateProps & Ge
       <div>
         <ProjectSettingsDialog project={project} />
         <ProjectHeader project={project} />
-        <ProjectBranches project={project} branches={branches!} count={3} />
+        <ProjectBranches project={project} branches={branches} count={3} />
         <ProjectActivity activities={activities!} isLoading={isLoadingActivities} />
       </div>
     );

--- a/src/js/components/project-view/project-branches.tsx
+++ b/src/js/components/project-view/project-branches.tsx
@@ -13,7 +13,7 @@ import BranchSummary from './branch-summary';
 const styles = require('./project-branches.scss');
 
 interface Props {
-  branches: (Branch | FetchError | undefined)[];
+  branches: (Branch | FetchError | undefined)[] | undefined;
   project: Project;
   showAll?: boolean;
   count?: number;
@@ -41,15 +41,21 @@ const getBranches = (branches: (Branch | FetchError | undefined)[]) => {
 };
 
 const ProjectBranches = ({ branches, project, showAll, count = 3 }: Props) => {
-  const branchesToShow = showAll ? branches : branches.slice(0, count);
-  const content = (branchesToShow.length === 0) ? getEmptyContent() : getBranches(branchesToShow);
+  let content: JSX.Element | JSX.Element[];
+  if (branches) {
+    const branchesToShow = showAll ? branches : branches.slice(0, count);
+    content = (branchesToShow.length === 0) ? getEmptyContent() : getBranches(branchesToShow);
+  } else {
+    content = getLoadingContent(0);
+  }
+
   const title = showAll ? `All branches for ${project.name}` : 'Branches';
 
   return (
     <section className="container">
       <SectionTitle><span>{title}</span></SectionTitle>
       {content}
-      {(!showAll && branches.length > count) && (
+      {(!showAll && branches && branches.length > count) && (
         <div className="row end-xs">
           <div className={classNames('col-xs-12', styles['show-all-branches-section'])}>
             <MinardLink className={styles['show-all-branches-link']} showAll project={project}>


### PR DESCRIPTION
Show a loading indicator in the branches section of the Project View until branches have been loaded. Until now, the whole page was hidden.
