### PR TITLE
Add basic team support

### DIFF
--- a/src/js/api/index.ts
+++ b/src/js/api/index.ts
@@ -1,6 +1,7 @@
 import 'isomorphic-fetch';
 import * as moment from 'moment';
 
+import { teamId } from './team-id';
 import { Api, ApiPromise } from './types';
 
 if (!process.env.CHARLES) {
@@ -93,7 +94,7 @@ const patchApi = (path: string, payload: any): ApiPromise =>
 
 const Activity = {
   fetchAll: (count: number, until?: number): ApiPromise => {
-    const query: any = { count };
+    const query: any = { count, filter: `team[${teamId}]` };
 
     if (until) {
       query.until = moment(until).toISOString();
@@ -135,7 +136,7 @@ const Deployment = {
 };
 
 const Project = {
-  fetchAll: (): ApiPromise => getApi('/teams/1/relationships/projects'), // TODO: add actual team Id
+  fetchAll: (): ApiPromise => getApi(`/teams/${teamId}/relationships/projects`),
   fetch: (id: string): ApiPromise => getApi(`/projects/${id}`),
   create: (name: string, description?: string): ApiPromise =>
     postApi('/projects', {
@@ -149,7 +150,7 @@ const Project = {
           team: {
             data: {
               type: 'teams',
-              id: 1, // TODO: add actual team ID
+              id: teamId,
             },
           },
         },

--- a/src/js/api/team-id.ts
+++ b/src/js/api/team-id.ts
@@ -1,0 +1,23 @@
+
+function getParameterByName(name: string) {
+  const url = window.location.href;
+  name = name.replace(/[\[\]]/g, '\\$&');
+  const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`);
+  const results = regex.exec(url);
+  if (!results) {
+    return null;
+  }
+  if (!results[2]) {
+    return '';
+  }
+  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
+function getTeamId() {
+  if (window && getParameterByName('teamId')) {
+    return getParameterByName('teamId');
+  }
+  return process.env.TEAM_ID ? process.env.TEAM_ID : 2;
+}
+
+export const teamId = getTeamId();

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 require('event-source-polyfill');
 
 import { toActivities, toBranches, toCommits, toDeployments, toProjects } from '../api/convert';
+import { teamId } from '../api/team-id';
 import {
   ResponseActivityElement,
   ResponseBranchElement,
@@ -94,7 +95,7 @@ let streamingAPIUrl: string = process.env.STREAMING_API || process.env.CHARLES;
 if (streamingAPIUrl) {
   // Remove trailing /
   streamingAPIUrl = streamingAPIUrl.replace(/\/$/, '');
-  streamingAPIUrl = `${streamingAPIUrl}/events/1`; // TODO: add actual team ID
+  streamingAPIUrl = `${streamingAPIUrl}/events/${teamId}`;
 }
 
 const toConnectionState = (state: any): ConnectionState => {

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-CHARLES=$1 npm run webpack-dev-server
+CHARLES=$1 TEAM_ID=$2 npm run webpack-dev-server

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,16 @@ const htmlWebpackPluginConfig = {
   },
 };
 
+function getTeamId() {
+  if (process.env.TEAM_ID) {
+    return process.env.TEAM_ID;
+  }
+  if (deployConfig.env === 'production') {
+    return 4;
+  }
+  return 3;
+}
+
 const config = {
   resolve: {
     modulesDirectories: ['node_modules'],
@@ -127,6 +137,7 @@ const config = {
     new HtmlWebpackPlugin(htmlWebpackPluginConfig),
     new webpack.DefinePlugin({
       'process.env.CHARLES': JSON.stringify(process.env.CHARLES || false),
+      'process.env.TEAM_ID': JSON.stringify(getTeamId()),
     }),
     new ExtractTextPlugin('bundled-[hash].css'),
     failPlugin,


### PR DESCRIPTION
This PR adds basic teamId support for `minard-ui`.

Can be tested with https://github.com/lucified/minard-backend/pull/72.

This is obviously a temporary solution, which we can use before we implement proper teams. We still need to figure out what to do with the team names shown in the ui.

We can leave that to another PR.
