### PR TITLE
Sort commits before adding them to branch

### DIFF
--- a/src/js/modules/branches/actions.ts
+++ b/src/js/modules/branches/actions.ts
@@ -15,16 +15,16 @@ export const loadBranchesForProject = (id: string): t.LoadBranchesForProjectActi
 });
 
 // Add commits to existing branch
-export const ADD_COMMITS_TO_BRANCH = 'BRANCHES/ADD_COMMITS_TO_BRANCH';
-export const addCommitsToBranch = (
+export const REPLACE_COMMITS_IN_BRANCH = 'BRANCHES/REPLACE_COMMITS_IN_BRANCH';
+export const replaceCommitsInBranch = (
   id: string,
   commitIds: string[],
-  requestedCount: number
-): t.AddCommitsToBranchAction => ({
-  type: ADD_COMMITS_TO_BRANCH,
+  allCommitsLoaded: boolean
+): t.ReplaceCommitsInBranchAction => ({
+  type: REPLACE_COMMITS_IN_BRANCH,
   id,
   commits: commitIds,
-  requestedCount,
+  allCommitsLoaded,
 });
 
 export const STORE_BRANCHES = 'BRANCHES/STORE_BRANCHES';

--- a/src/js/modules/branches/types.ts
+++ b/src/js/modules/branches/types.ts
@@ -33,10 +33,10 @@ export interface LoadBranchesForProjectAction extends Action {
 }
 
 // ADD_COMMITS_TO_BRANCH
-export interface AddCommitsToBranchAction extends Action {
+export interface ReplaceCommitsInBranchAction extends Action {
   id: string;
   commits: string[];
-  requestedCount: number;
+  allCommitsLoaded: boolean;
 }
 
 // STORE_BRANCHES

--- a/src/js/sagas/utils.ts
+++ b/src/js/sagas/utils.ts
@@ -25,7 +25,7 @@ interface StoreEntityAction extends Action {
 
 export const createLoader = (
   selector: (state: StateTree, id: string) => SelectorResponse,
-  fetcher: (id: string) => IterableIterator<Effect>,
+  fetcher: (id: string) => IterableIterator<Effect | Effect[]>,
   dataEnsurer: (id: string) => IterableIterator<Effect | Effect[]>
 ) => {
   return function* (action: LoadEntityAction): IterableIterator<Effect> { // tslint:disable-line:only-arrow-functions
@@ -48,9 +48,9 @@ export const createEntityFetcher = <ResponseEntity, ApiParams>(
   converter: (apiEntities: ApiEntity[] | ApiEntity) => EntityType[],
   storeEntitiesActionCreator: (entities: EntityType[]) => StoreEntityAction,
   apiFetchFunction: (id: string, ...args: ApiParams[]) => ApiPromise,
-  postStoreEffects?: (id: string, response: ApiResponse, ...args: ApiParams[]) => IterableIterator<Effect>,
+  postStoreEffects?: (id: string, response: ApiResponse, ...args: ApiParams[]) => IterableIterator<Effect | Effect[]>,
 ) => {
-  return function* (id: string, ...args: ApiParams[]): IterableIterator<Effect> { // tslint:disable-line
+  return function* (id: string, ...args: ApiParams[]): IterableIterator<Effect | Effect[]> { // tslint:disable-line
     yield put(requestActionCreators.REQUEST.actionCreator(id));
 
     const { response, error, details }: { response?: ApiResponse, error?: string, details?: string } =


### PR DESCRIPTION
When loading a project, we also fetch the latest commit and latest deployed commit (which might both be the same). However, if these are not the latest or the two latest commits in the branch, when we fetch the whole commit list (i.e. open Branch View), the new fetched commits would simply be appended to the commit list. In other words, we need to sort the commits before adding them to the branch. This is a bit tricky since the branch only has an array of commit IDs, and the commit entities might be `FetchError`s or `undefined`s in the state tree. If we encounter these, we simply add the IDs for these to the end of the sorted commit ID array.

I just realized there's another alternative solution to this problem: not storing the latestCommit or latestDeployedCommit to the `commits` array for branches. We would only populate the array when we open the Branch View, and simply append commits to the end of the array as they are fetched from the server (since they always arrive sorted and are fetched in order).

Would this second approach be better?
