### PR TITLE
Don't add latestCommit or latestSuccessfullyDeployedCommit to branch commits

### DIFF
--- a/src/js/api/convert.ts
+++ b/src/js/api/convert.ts
@@ -144,15 +144,6 @@ const createBranchObject = (branch: t.ResponseBranchElement): Branch => {
     latestCommitObject.data &&
     latestCommitObject.data.id;
 
-  const commits: string[] = [];
-  // Make sure latestSuccessfullyDeployedCommit and latestCommit are included in the list
-  if (latestCommit) {
-    commits.push(latestCommit);
-  }
-  if (latestSuccessfullyDeployedCommit && latestSuccessfullyDeployedCommit !== latestCommit) {
-    commits.push(latestSuccessfullyDeployedCommit);
-  }
-
   const latestActivityTimestampString = branch.attributes['latest-activity-timestamp'];
   let latestActivityTimestamp: number | undefined;
 
@@ -173,8 +164,8 @@ const createBranchObject = (branch: t.ResponseBranchElement): Branch => {
     project: branch.relationships.project.data.id,
     buildErrors: errors,
     latestActivityTimestamp,
-    commits,
-    allCommitsLoaded: commits.length === 0,
+    commits: [],
+    allCommitsLoaded: !latestCommit,
     latestCommit,
     latestSuccessfullyDeployedCommit,
   };


### PR DESCRIPTION
Ensure that the only way to add content to branch.commits is when it comes in order from the server: when opening the Branch View and asking for the commits for the branch, or when new commits appear through the streaming API.

This fixes a bug: when loading a project, we fetch the latest commit and latest deployed commit (which might both be the same) and add these to the branch's commit list. However, if these are not the latest commits in the branch, when we fetch the whole commit list (i.e. open Branch View), the new fetched commits would simply be appended to the commit list, resulting in a commit list that was not ordered properly.
