### PR TITLE
Fix broken staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-addons-css-transition-group": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-flip-move": "^2.7.1",
-    "react-fontawesome": "^1.4.0",
+    "react-fontawesome": "1.3.1",
     "react-gravatar": "^2.6.1",
     "react-modal": "1.2.1",
     "react-redux": "^4.4.6",


### PR DESCRIPTION
The culprit ended up being `react-fontawesome`, not `react-flip-move`: https://github.com/danawoodman/react-fontawesome/issues/32

Downgrade to a previous version that works.