### PR TITLE
Show the loading icon when opening the Branch View

### DIFF
--- a/src/js/components/branch-view/index.tsx
+++ b/src/js/components/branch-view/index.tsx
@@ -91,6 +91,10 @@ class BranchView extends React.Component<GeneratedStateProps & PassedProps & Gen
       return this.getErrorContent(project);
     }
 
+    if (isLoadingCommits && commits!.length === 0) {
+      return this.getLoadingContent();
+    }
+
     return (
       <div>
         <BranchHeader project={project} branch={branch} />


### PR DESCRIPTION
Fixes #128. The “no commits in branch” icon used to flicker onto the screen for a moment until the commits were loaded.