### PR TITLE
Better form error messages

### DIFF
--- a/src/js/modules/requests/index.ts
+++ b/src/js/modules/requests/index.ts
@@ -6,8 +6,10 @@ export default { actions, reducer, selectors };
 export {
   CollectionActionCreators,
   CreateEntityActionCreators,
+  CreateEntitySuccessAction,
   DeleteEntityActionCreators,
   EditEntityActionCreators,
+  EditEntitySuccessAction,
   EntityRequestAction,
   EntitySuccessAction,
   FetchEntityActionCreators,

--- a/src/js/modules/requests/types.ts
+++ b/src/js/modules/requests/types.ts
@@ -57,7 +57,7 @@ interface CreateEntityRequestActionCreator {
 }
 
 // When request succeeds
-interface CreateEntitySuccessAction extends Action {
+export interface CreateEntitySuccessAction extends Action {
   result: Object;
   name: string;
 }
@@ -66,7 +66,7 @@ interface CreateEntitySuccessActionCreator {
   (entity: any, name: string): CreateEntitySuccessAction;
 }
 
-interface EditEntitySuccessAction extends Action {
+export interface EditEntitySuccessAction extends Action {
   result: Object;
 }
 

--- a/src/js/sagas/index.ts
+++ b/src/js/sagas/index.ts
@@ -21,7 +21,7 @@ import Comments, {
 } from '../modules/comments';
 import Commits, { Commit, LoadCommitsForBranchAction } from '../modules/commits';
 import Deployments, { Deployment, StoreDeploymentsAction } from '../modules/deployments';
-import { FetchError, isFetchError } from '../modules/errors';
+import { CreateError, EditError, FetchError, isFetchError } from '../modules/errors';
 import { FORM_SUBMIT, FormSubmitAction } from '../modules/forms';
 import Previews, { LoadPreviewAction, Preview } from '../modules/previews';
 import Projects, {
@@ -32,7 +32,7 @@ import Projects, {
   Project,
   StoreProjectsAction,
 } from '../modules/projects';
-import Requests from '../modules/requests';
+import Requests, { CreateEntitySuccessAction, EditEntitySuccessAction } from '../modules/requests';
 
 // Loaders check whether an entity exists. If not, fetch it with a fetcher.
 // Afterwards, the loader also ensures that other needed data exists.
@@ -587,7 +587,10 @@ export default function createSagas(api: Api) {
   }: FormSubmitAction): IterableIterator<Effect> {
     yield put({ type: submitAction, payload: values });
 
-    const { success, failure } = yield race({
+    const { success, failure }: {
+      success: CreateEntitySuccessAction | EditEntitySuccessAction,
+      failure: CreateError | EditError,
+    } = yield race({
       success: take(successAction),
       failure: take(failureAction),
     });


### PR DESCRIPTION
When you e.g. try to create a new project using an empty project as a template, the error that is shown is simply "Bad request". Now show the actual error message sent by the server.