### PR TITLE
Add maximum length validation to project names

### DIFF
--- a/src/js/components/project-view/project-settings-form.tsx
+++ b/src/js/components/project-view/project-settings-form.tsx
@@ -43,12 +43,14 @@ const validate = (values: EditProjectFormData, props: Props) => {
     errors.name = 'Only letters, numbers, and hyphens allowed';
   } else if (name[0] === '-') {
     errors.name = 'Project name can\'t start with a hyphen';
+  } else if (name.length > 251) {
+    errors.name = 'Maximum length of 251 characters';
   } else if (props.existingProjectNames.indexOf(name) > -1) {
     errors.name = 'Project name already exists';
   }
 
   if (description && description.length > 2000) {
-    errors.description = 'The description can be up to 2000 characters long';
+    errors.description = 'Maximum length of 2000 characters';
   }
 
   return errors;

--- a/src/js/components/team-projects-view/new-project-form.tsx
+++ b/src/js/components/team-projects-view/new-project-form.tsx
@@ -32,12 +32,14 @@ const validate = (values: CreateProjectFormData, props: Props) => {
     errors.name = 'Only letters, numbers, and hyphens allowed';
   } else if (name[0] === '-') {
     errors.name = 'Project name can\'t start with a hyphen';
+  } else if (name.length > 251) {
+    errors.name = 'Maximum length of 251 characters';
   } else if (props.existingProjects.find(project => project.name === name)) {
     errors.name = 'Project name already exists';
   }
 
   if (description && description.length > 2000) {
-    errors.description = 'The description can be up to 2000 characters long';
+    errors.description = 'Maximum length of 2000 characters';
   }
 
   return errors;


### PR DESCRIPTION
Adds a limit of 251 characters to project names.

Are there other server-side limitations/validations that are missing in minard-ui?