### PR TITLE
Fix loading and displaying of comments in Deployment View

### DIFF
--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import Comments from '../../modules/comments';
 import Commits, { Commit } from '../../modules/commits';
 import Deployments, { Deployment } from '../../modules/deployments';
 import { FetchError, isFetchError } from '../../modules/errors';
@@ -34,28 +33,25 @@ interface GeneratedStateProps {
 }
 
 interface GeneratedDispatchProps {
-  loadPreview: (deploymentId: string, commitHash: string) => void;
-  loadCommentsForDeployment: (deploymentId: string) => void;
+  loadPreviewAndComments: (deploymentId: string, commitHash: string) => void;
 }
 
 type Props = PassedProps & GeneratedStateProps & GeneratedDispatchProps;
 
 class ProjectsFrame extends React.Component<Props, any> {
   public componentWillMount() {
-    const { loadCommentsForDeployment, loadPreview } = this.props;
+    const { loadPreviewAndComments } = this.props;
     const { deploymentId, commitHash } = this.props.params;
 
-    loadPreview(deploymentId, commitHash);
-    loadCommentsForDeployment(deploymentId);
+    loadPreviewAndComments(deploymentId, commitHash);
   }
 
   public componentWillReceiveProps(nextProps: Props) {
-    const { loadCommentsForDeployment, loadPreview } = nextProps;
+    const { loadPreviewAndComments } = nextProps;
     const { commitHash, deploymentId } = nextProps.params;
 
     if (deploymentId !== this.props.params.deploymentId) {
-      loadPreview(deploymentId, commitHash);
-      loadCommentsForDeployment(deploymentId);
+      loadPreviewAndComments(deploymentId, commitHash);
     }
   }
 
@@ -123,7 +119,6 @@ const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStat
 export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
   mapStateToProps,
   {
-    loadPreview: Previews.actions.loadPreview,
-    loadCommentsForDeployment: Comments.actions.loadCommentsForDeployment,
+    loadPreviewAndComments: Previews.actions.loadPreviewAndComments,
   },
 )(ProjectsFrame);

--- a/src/js/modules/comments/actions.ts
+++ b/src/js/modules/comments/actions.ts
@@ -1,11 +1,5 @@
 import * as t from './types';
 
-export const LOAD_COMMENTS_FOR_DEPLOYMENT = 'COMMENTS/LOAD_COMMENTS_FOR_DEPLOYMENT';
-export const loadCommentsForDeployment = (id: string): t.LoadCommentsForDeploymentAction => ({
-  type: LOAD_COMMENTS_FOR_DEPLOYMENT,
-  id,
-});
-
 export const DELETE_COMMENT = 'COMMENTS/DELETE_COMMENT';
 export const deleteComment = (id: string): t.DeleteCommentAction => ({
   type: DELETE_COMMENT,

--- a/src/js/modules/comments/index.ts
+++ b/src/js/modules/comments/index.ts
@@ -9,5 +9,4 @@ export {
   CreateCommentAction,
   CreateCommentFormData,
   DeleteCommentAction,
-  LoadCommentsForDeploymentAction,
 } from './types';

--- a/src/js/modules/comments/types.ts
+++ b/src/js/modules/comments/types.ts
@@ -15,11 +15,6 @@ export interface CommentState {
 };
 
 // Actions
-// LOAD_COMMENTS_FOR_DEPLOYMENT
-export interface LoadCommentsForDeploymentAction extends Action {
-  id: string;
-}
-
 // DELETE_COMMENT
 export interface DeleteCommentAction extends Action {
   id: string;

--- a/src/js/modules/deployments/reducer.ts
+++ b/src/js/modules/deployments/reducer.ts
@@ -58,6 +58,7 @@ const reducer: Reducer<t.DeploymentState> = (state = initialState, action: any) 
       logMessage('Deployment entity does not exist when setting comments', { action });
 
       return state;
+    // Add/replace deployments into state
     case STORE_DEPLOYMENTS:
       const deploymentsArray = (<t.StoreDeploymentsAction> action).entities;
       if (deploymentsArray && deploymentsArray.length > 0) {

--- a/src/js/modules/previews/actions.ts
+++ b/src/js/modules/previews/actions.ts
@@ -6,9 +6,9 @@ export const storePreviews = (preview: t.Preview): t.StorePreviewAction => ({
   preview,
 });
 
-export const LOAD_PREVIEW = 'PREVIEW/LOAD_PREVIEW';
-export const loadPreview = (id: string, commitHash: string): t.LoadPreviewAction => ({
-  type: LOAD_PREVIEW,
+export const LOAD_PREVIEW_AND_COMMENTS = 'PREVIEW/LOAD_PREVIEW_AND_COMMENTS';
+export const loadPreviewAndComments = (id: string, commitHash: string): t.LoadPreviewAndCommentsAction => ({
+  type: LOAD_PREVIEW_AND_COMMENTS,
   id,
   commitHash,
 });

--- a/src/js/modules/previews/index.ts
+++ b/src/js/modules/previews/index.ts
@@ -4,7 +4,7 @@ import * as selectors from './selectors';
 
 export default { actions, reducer, selectors };
 export {
-  LoadPreviewAction,
+  LoadPreviewAndCommentsAction,
   Preview,
   PreviewState,
 } from './types';

--- a/src/js/modules/previews/types.ts
+++ b/src/js/modules/previews/types.ts
@@ -23,8 +23,8 @@ export interface PreviewState {
 };
 
 // Actions
-// LOAD_PREVIEW
-export interface LoadPreviewAction extends Action {
+// LOAD_PREVIEW_AND_COMMENTS
+export interface LoadPreviewAndCommentsAction extends Action {
   id: string;
   commitHash: string;
 }


### PR DESCRIPTION
Make fetching of preview and comments an atomic action. This fixes the situation where the comments finished loading before the preview. In those situations, the deployment's comments array would be reset when the preview finished loading.