### PR TITLE
Remove webpack-fail-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
     "typescript": "^2.1.5",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^1.16.2",
-    "webpack-fail-plugin": "^1.0.5"
+    "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const autoprefixer = require('autoprefixer');
 const postcssReporter = require('postcss-reporter');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const failPlugin = require('webpack-fail-plugin');
 
 const deployConfig = require('./deploy-config');
 
@@ -187,7 +186,6 @@ const config = {
       from: 'src/images/favicon-*.png',
       flatten: true,
     }]),
-    failPlugin,
   ],
 };
 


### PR DESCRIPTION
Webpack 2 now returns a non-zero exit code when building fails, making this plugin unnecessary