### PR TITLE
Fix forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "raven-js": "^3.10.0",
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^15.4.2",
-    "react-autosize-textarea": "^0.3.6",
+    "react-autosize-textarea": "0.3.4",
     "react-dom": "^15.4.2",
     "react-flip-move": "^2.8.0",
     "react-fontawesome": "1.3.1",


### PR DESCRIPTION
The latest version of react-autosize-textarea breaks forms. Revert to an older version.