### PR TITLE
Fix logout

### DIFF
--- a/src/js/api/auth.ts
+++ b/src/js/api/auth.ts
@@ -33,7 +33,7 @@ export function getEmail(): string | null {
   return getAccessToken() && localStorage.getItem(EMAIL_KEY);
 };
 
-export function clearCredentials() {
+export function clearStoredCredentials() {
   localStorage.removeItem(ID_TOKEN_KEY);
   localStorage.removeItem(ACCESS_TOKEN_KEY);
   localStorage.removeItem(EXPIRES_AT_KEY);

--- a/src/js/components/header.tsx
+++ b/src/js/components/header.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { Link } from 'react-router';
 
-import { clearCredentials } from '../api/auth';
+import { clearStoredCredentials } from '../api/auth';
 import { logout as intercomLogout } from '../intercom';
 import Errors, { FetchCollectionError } from '../modules/errors';
 import Selected from '../modules/selected';
@@ -51,7 +51,7 @@ class Header extends React.Component<Props, void> {
   private logout(_e: any) {
     intercomLogout();
     this.props.clearUserDetails();
-    clearCredentials();
+    clearStoredCredentials();
   }
 
   public render() {

--- a/src/js/components/header.tsx
+++ b/src/js/components/header.tsx
@@ -30,6 +30,7 @@ interface GeneratedStateProps {
 
 interface GeneratedDispatchProps {
   clearUserDetails: () => void;
+  clearData: () => void;
 }
 
 type Props = PassedProps & GeneratedStateProps & GeneratedDispatchProps;
@@ -50,6 +51,7 @@ class Header extends React.Component<Props, void> {
 
   private logout(_e: any) {
     intercomLogout();
+    this.props.clearData();
     this.props.clearUserDetails();
     clearStoredCredentials();
   }
@@ -141,6 +143,7 @@ const mapStateToProps = (state: StateTree): GeneratedStateProps => {
 
 const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
   clearUserDetails: () => { dispatch(User.actions.clearUserDetails()); },
+  clearData: () => { dispatch(User.actions.clearStoredData()); },
 });
 
 export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(

--- a/src/js/components/login-view/index.tsx
+++ b/src/js/components/login-view/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { push } from 'react-router-redux';
 
-import { storeCredentials } from '../../api/auth';
+import { clearStoredCredentials, storeCredentials } from '../../api/auth';
 import { login as intercomLogin } from '../../intercom';
 import User from '../../modules/user';
 
@@ -21,6 +21,10 @@ class LoginView extends React.Component<Props, void> {
   private lock: Auth0LockStatic;
 
   public componentDidMount() {
+    // Remove stored credentials. E.g. if there is an old access token stored that
+    // has expired.
+    clearStoredCredentials();
+
     this.lock = new Auth0Lock(process.env.AUTH0_CLIENT_ID, process.env.AUTH0_DOMAIN, {
       // oidcConformant is still in preview stage, which is why it is not documented
       // or found in the typings. Remove the `as any` below once it's included.

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -1,6 +1,6 @@
 import { uniq } from 'lodash';
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect, Dispatch } from 'react-redux';
 
 require('event-source-polyfill');
 
@@ -376,30 +376,73 @@ const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
   team: User.selectors.getTeam(state),
 });
 
-export default connect<{}, GeneratedDispatchProps, {}>(
-  mapStateToProps,
-  {
-    setConnectionState: Streaming.actions.setConnectionState,
-    storeActivities: Activities.actions.storeActivities,
-    removeBranch: Branches.actions.removeBranch,
-    updateBranchWithCommits: Branches.actions.updateBranchWithCommits,
-    updateLatestDeployedCommitForBranch: Branches.actions.updateLatestDeployedCommit,
-    storeBranches: Branches.actions.storeBranches,
-    addDeploymentToCommit: Commits.actions.addDeploymentToCommit,
-    storeComments: Comments.actions.storeComments,
-    removeComment: Comments.actions.removeComment,
-    addCommentsToDeployment: Deployments.actions.addCommentsToDeployment,
-    removeCommentFromDeployment: Deployments.actions.removeCommentFromDeployment,
-    storeCommits: Commits.actions.storeCommits,
-    storeDeployments: Deployments.actions.storeDeployments,
-    updateProject: Projects.actions.updateProject,
-    removeProject: Projects.actions.removeProject,
-    storeProjects: Projects.actions.storeProjects,
-    storeAuthorsToProject: Projects.actions.storeAuthorsToProject,
-    addBranchToProject: Projects.actions.addBranchesToProject,
-    updateLatestActivityTimestampForProject: Projects.actions.updateLatestActivityTimestampForProject,
-    updateLatestDeployedCommitForProject: Projects.actions.updateLatestDeployedCommitForProject,
-    updateLatestActivityTimestampForBranch: Branches.actions.updateLatestActivityTimestampForBranch,
-    removeBranchFromProject: Projects.actions.removeBranchFromProject,
+const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
+  // Activities
+  storeActivities: (activities: Activity[]) => { dispatch(Activities.actions.storeActivities(activities)); },
+
+  // Branches
+  storeBranches: (branches: Branch[]) => { dispatch(Branches.actions.storeBranches(branches)); },
+  removeBranch: (id: string) => { dispatch(Branches.actions.removeBranch(id)); },
+  updateBranchWithCommits: (id: string, latestCommitId: string, newCommits: Commit[], parentCommits: string[]) => {
+    dispatch(Branches.actions.updateBranchWithCommits(id, latestCommitId, newCommits, parentCommits));
   },
+  updateLatestActivityTimestampForBranch: (id: string, timestamp: number) => {
+    dispatch(Branches.actions.updateLatestActivityTimestampForBranch(id, timestamp));
+  },
+  updateLatestDeployedCommitForBranch: (id: string, commit: string) => {
+    dispatch(Branches.actions.updateLatestDeployedCommit(id, commit));
+  },
+
+  // Comments
+  storeComments: (comments: Comment[]) => { dispatch(Comments.actions.storeComments(comments)); },
+  removeComment: (comment: string) => { dispatch(Comments.actions.removeComment(comment)); },
+
+  // Commits
+  storeCommits: (commits: Commit[]) => { dispatch(Commits.actions.storeCommits(commits)); },
+  addDeploymentToCommit: (commitId: string, deploymentId: string) => {
+    dispatch(Commits.actions.addDeploymentToCommit(commitId, deploymentId));
+  },
+
+  // Deployments
+  storeDeployments: (deployments: Deployment[]) => {
+    dispatch(Deployments.actions.storeDeployments(deployments));
+  },
+  addCommentsToDeployment: (id: string, comments: string[]) => {
+    dispatch(Deployments.actions.addCommentsToDeployment(id, comments));
+  },
+  removeCommentFromDeployment: (id: string, comment: string) => {
+    dispatch(Deployments.actions.removeCommentFromDeployment(id, comment));
+  },
+
+  // Projects
+  storeProjects: (projects: Project[]) => { dispatch(Projects.actions.storeProjects(projects)); },
+  removeProject: (id: string) => { dispatch(Projects.actions.removeProject(id)); },
+  updateProject: (id: string, name: string, repoUrl: string, description?: string) => {
+    dispatch(Projects.actions.updateProject(id, name, repoUrl, description));
+  },
+  storeAuthorsToProject: (id: string, authors: ProjectUser[]) => {
+    dispatch(Projects.actions.storeAuthorsToProject(id, authors));
+  },
+  addBranchToProject: (id: string, branch: string) => {
+    dispatch(Projects.actions.addBranchesToProject(id, branch));
+  },
+  updateLatestActivityTimestampForProject: (id: string, timestamp: number) => {
+    dispatch(Projects.actions.updateLatestActivityTimestampForProject(id, timestamp));
+  },
+  updateLatestDeployedCommitForProject: (id: string, commit: string) => {
+    dispatch(Projects.actions.updateLatestDeployedCommitForProject(id, commit));
+  },
+  removeBranchFromProject: (id: string, branch: string) => {
+    dispatch(Projects.actions.removeBranchFromProject(id, branch));
+  },
+
+  // Streaming
+  setConnectionState: (state: ConnectionState, error?: string) => {
+    dispatch(Streaming.actions.setConnectionState(state, error));
+  },
+});
+
+export default connect<GeneratedStateProps, GeneratedDispatchProps, {}>(
+  mapStateToProps,
+  mapDispatchToProps,
 )(StreamingAPIHandler);

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -338,21 +338,32 @@ class StreamingAPIHandler extends React.Component<Props, void> {
   public componentWillMount() {
     const { team } = this.props;
 
-    // TODO: handle situation when not an authenticated Minard user
+    // TODO: handle situation when user has Deployment View open and is not a logged in Minard user
     if (streamingAPIUrl && team) {
       this.restartConnection(team.id);
     }
   }
 
   public componentWillReceiveProps(nextProps: Props) {
-    if (!this.props.team && nextProps.team) {
+    const { team, setConnectionState } = this.props;
+
+    // User logged in
+    if (streamingAPIUrl && !team && nextProps.team) {
       this.restartConnection(nextProps.team.id);
+    }
+
+    // User logged out
+    if (team && !nextProps.team) {
+      setConnectionState(ConnectionState.INITIAL_CONNECT);
+      this._source.close();
+      this._source = null;
     }
   }
 
   public componentWillUnmount() {
     if (this._source) {
       this._source.close();
+      this._source = null;
     }
   }
 

--- a/src/js/modules/activities/reducer.ts
+++ b/src/js/modules/activities/reducer.ts
@@ -1,6 +1,7 @@
 import { mapKeys } from 'lodash';
 import { Reducer } from 'redux';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { STORE_ACTIVITIES } from './actions';
 import * as t from './types';
 
@@ -20,6 +21,8 @@ const reducer: Reducer<t.ActivityState> = (state: t.ActivityState = initialState
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/branches/reducer.ts
+++ b/src/js/modules/branches/reducer.ts
@@ -4,6 +4,7 @@ import { Reducer } from 'redux';
 import { logMessage } from '../../logger';
 import { FetchError, isFetchError } from '../errors';
 import Requests from '../requests';
+import { CLEAR_STORED_DATA } from '../user';
 
 import {
   ADD_COMMITS_TO_BRANCH,
@@ -161,6 +162,8 @@ const reducer: Reducer<t.BranchState> = (state = initialState, action: any) => {
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/comments/reducer.ts
+++ b/src/js/modules/comments/reducer.ts
@@ -1,6 +1,7 @@
 import { mapKeys, omit } from 'lodash';
 import { Reducer } from 'redux';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { REMOVE_COMMENT, STORE_COMMENTS } from './actions';
 import * as t from './types';
 
@@ -27,6 +28,8 @@ const reducer: Reducer<t.CommentState> = (state = initialState, action: any) => 
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/commits/reducer.ts
+++ b/src/js/modules/commits/reducer.ts
@@ -5,6 +5,7 @@ import { logMessage } from '../../logger';
 import { FetchError, isFetchError } from '../errors';
 import Requests from '../requests';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { ADD_DEPLOYMENT_TO_COMMIT, STORE_COMMITS } from './actions';
 import * as t from './types';
 
@@ -62,6 +63,8 @@ const reducer: Reducer<t.CommitState> = (state = initialState, action: any) => {
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/deployments/reducer.ts
+++ b/src/js/modules/deployments/reducer.ts
@@ -4,6 +4,7 @@ import { Reducer } from 'redux';
 import { logMessage } from '../../logger';
 import { FetchError, isFetchError } from '../errors';
 import Requests from '../requests';
+import { CLEAR_STORED_DATA } from '../user';
 
 import {
   ADD_COMMENTS_TO_DEPLOYMENT,
@@ -137,6 +138,8 @@ const reducer: Reducer<t.DeploymentState> = (state = initialState, action: any) 
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/errors/reducer.ts
+++ b/src/js/modules/errors/reducer.ts
@@ -2,6 +2,7 @@ import { Reducer } from 'redux';
 
 import Requests from '../requests';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { CLEAR_PROJECT_DELETION_ERRORS, CLEAR_SIGNUP_ERROR, SIGNUP_ERROR } from './actions';
 import * as t from './types';
 
@@ -45,6 +46,8 @@ const reducer: Reducer<t.ErrorState> = (state = initialState, action: any) => {
         state,
         error => error.type !== SIGNUP_ERROR,
       );
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/modal/reducer.ts
+++ b/src/js/modules/modal/reducer.ts
@@ -1,5 +1,6 @@
 import { Reducer } from 'redux';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { CLOSE_MODAL, OPEN_MODAL } from './actions';
 import * as t from './types';
 
@@ -21,6 +22,8 @@ const reducer: Reducer<t.ModalState> = (state: t.ModalState = initialState, acti
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/previews/reducer.ts
+++ b/src/js/modules/previews/reducer.ts
@@ -3,6 +3,7 @@ import { Reducer } from 'redux';
 import { FetchError, isFetchError } from '../errors';
 import Requests from '../requests';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { STORE_PREVIEW } from './actions';
 import * as t from './types';
 
@@ -36,6 +37,8 @@ const reducer: Reducer<t.PreviewState> = (state = initialState, action: any) => 
       console.error('No preview found when storing preview.', action);
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/projects/reducer.ts
+++ b/src/js/modules/projects/reducer.ts
@@ -4,6 +4,7 @@ import { Reducer } from 'redux';
 import { logMessage } from '../../logger';
 import { DeleteError, FetchError, isFetchError } from '../errors';
 import Requests from '../requests';
+import { CLEAR_STORED_DATA } from '../user';
 
 import {
   ADD_BRANCHES_TO_PROJECT,
@@ -218,6 +219,8 @@ const reducer: Reducer<t.ProjectState> = (state = initialState, action: any) => 
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/requests/reducer.ts
+++ b/src/js/modules/requests/reducer.ts
@@ -1,6 +1,7 @@
 import { Reducer } from 'redux';
 
 import { DeleteError, FetchError } from '../errors';
+import { CLEAR_STORED_DATA } from '../user';
 import * as actions from './actions';
 import * as t from './types';
 
@@ -86,6 +87,8 @@ const reducer: Reducer<t.RequestsState> = (state = initialState, action: any) =>
         requestInfo => (requestInfo.type !== actions.Projects.DeleteProject.REQUEST.type) ||
           (requestInfo.id !== deleteProjectAction.id),
       );
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/selected/reducer.ts
+++ b/src/js/modules/selected/reducer.ts
@@ -1,5 +1,6 @@
 import { Reducer } from 'redux';
 
+import { CLEAR_STORED_DATA } from '../user';
 import { SET_SELECTED } from './actions';
 import * as t from './types';
 
@@ -23,6 +24,8 @@ const reducer: Reducer<t.SelectedState> = (state = initialState, action: any) =>
       }
 
       return state;
+    case CLEAR_STORED_DATA:
+      return initialState;
     default:
       return state;
   }

--- a/src/js/modules/user/actions.ts
+++ b/src/js/modules/user/actions.ts
@@ -1,4 +1,5 @@
 import {
+  ClearStoredDataAction,
   ClearUserDetailsAction,
   LoadTeamInformationAction,
   SetGitPasswordAction,
@@ -23,6 +24,11 @@ export const setTeam = (id: string, name: string): SetTeamAction => ({
 export const CLEAR_USER_DETAILS = 'USER/CLEAR_USER_DETAILS';
 export const clearUserDetails = (): ClearUserDetailsAction => ({
   type: CLEAR_USER_DETAILS,
+});
+
+export const CLEAR_STORED_DATA = 'USER/CLEAR_STORED_DATA';
+export const clearStoredData = (): ClearStoredDataAction => ({
+  type: CLEAR_STORED_DATA,
 });
 
 export const LOAD_TEAM_INFORMATION = 'USER/LOAD_TEAM_INFORMATION';

--- a/src/js/modules/user/index.ts
+++ b/src/js/modules/user/index.ts
@@ -4,3 +4,4 @@ import * as selectors from './selectors';
 
 export default { reducer, selectors, actions };
 export { Team, UserState, LoadTeamInformationAction, SignupUserAction } from './types';
+export { CLEAR_STORED_DATA } from './actions';

--- a/src/js/modules/user/types.ts
+++ b/src/js/modules/user/types.ts
@@ -27,6 +27,10 @@ export interface ClearUserDetailsAction {
   type: 'USER/CLEAR_USER_DETAILS';
 }
 
+export interface ClearStoredDataAction {
+  type: 'USER/CLEAR_STORED_DATA';
+}
+
 export interface LoadTeamInformationAction {
   type: 'USER/LOAD_TEAM_INFORMATION';
 };


### PR DESCRIPTION
This can be tested by logging in with a user on one team, logging out, then logging in with a user from another team. Before, the new data was appended to the end of the old user's data. Now all data is cleared on logout.

Fixes #209.

Fixes a few other things as well:
- When logging out, the realtime stream is now disconnected.
- Some minor refactorings.
- Clears user credentials when Login View is opened.