### PR TITLE
Use user email address for comments

### DIFF
--- a/src/js/components/deployment-view/comment-list.tsx
+++ b/src/js/components/deployment-view/comment-list.tsx
@@ -14,7 +14,7 @@ interface PassedProps {
   commentIds: string[];
   className?: string;
   highlightComment?: string;
-  authenticatedUser: boolean;
+  isAuthenticatedUser: boolean;
 }
 
 interface GeneratedStateProps {
@@ -79,7 +79,7 @@ class CommentList extends React.Component<Props, void> {
   }
 
   public render() {
-    const { authenticatedUser, commentIds, comments, className, highlightComment } = this.props;
+    const { isAuthenticatedUser, commentIds, comments, className, highlightComment } = this.props;
 
     return (
       <div ref={this.storeListRef} className={classNames(styles['comment-list'], className)}>
@@ -97,7 +97,7 @@ class CommentList extends React.Component<Props, void> {
                   { [styles.highlighted]: isHighlighted },
                 )}
               >
-                <SingleComment comment={comment} hideDelete={!authenticatedUser} />
+                <SingleComment comment={comment} hideDelete={!isAuthenticatedUser} />
               </div>
             );
           })}

--- a/src/js/components/deployment-view/commit-summary.tsx
+++ b/src/js/components/deployment-view/commit-summary.tsx
@@ -14,11 +14,11 @@ interface Props {
   commit: Commit;
   deployment: Deployment;
   preview: Preview;
-  authenticatedUser: boolean;
+  isAuthenticatedUser: boolean;
 }
 
-const CommitSummary = ({ authenticatedUser, className, commit, deployment, preview }: Props) => {
-  const metadata = authenticatedUser ? (
+const CommitSummary = ({ isAuthenticatedUser, className, commit, deployment, preview }: Props) => {
+  const metadata = isAuthenticatedUser ? (
     <div className={styles.metadata}>
       <MinardLink branch={preview.branch.id} project={preview.project.id}>
         {preview.branch.name}

--- a/src/js/components/deployment-view/header.tsx
+++ b/src/js/components/deployment-view/header.tsx
@@ -16,11 +16,11 @@ interface Props {
   onToggleOpen: (e: React.MouseEvent<HTMLElement>) => void;
   isOpen: boolean;
   className?: string;
-  authenticatedUser: boolean;
+  isAuthenticatedUser: boolean;
 }
 
 const Header = (
-  { authenticatedUser, buildLogSelected, className, commit, deployment, isOpen, onToggleOpen }: Props,
+  { isAuthenticatedUser, buildLogSelected, className, commit, deployment, isOpen, onToggleOpen }: Props,
 ) => (
   <div className={classNames(styles.header, className)}>
     {buildLogSelected ? (
@@ -55,7 +55,7 @@ const Header = (
             Preview
           </a>
         )}
-        {authenticatedUser && (
+        {isAuthenticatedUser && (
           <MinardLink preview={deployment} commit={commit} buildLog className={styles.tab}>
             Build log
           </MinardLink>

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -33,6 +33,7 @@ interface GeneratedStateProps {
   commit?: Commit | FetchError;
   deployment?: Deployment | FetchError;
   isUserLoggedIn: boolean;
+  userEmail?: string;
 }
 
 interface GeneratedDispatchProps {
@@ -59,7 +60,7 @@ class ProjectsFrame extends React.Component<Props, void> {
   }
 
   public render() {
-    const { commit, deployment, preview, params, isUserLoggedIn } = this.props;
+    const { commit, deployment, preview, params, isUserLoggedIn, userEmail } = this.props;
 
     if (!preview) {
       return <div>Loading...</div>;
@@ -96,6 +97,7 @@ class ProjectsFrame extends React.Component<Props, void> {
           buildLogSelected={!showPreview}
           highlightComment={params.commentId}
           isAuthenticatedUser={isUserLoggedIn}
+          userEmail={userEmail}
         />
         <iframe className={styles.preview} src={showPreview ? deployment.url : getBuildLogURL(deployment.id)} />
       </div>
@@ -119,6 +121,7 @@ const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStat
     commit,
     deployment,
     isUserLoggedIn: User.selectors.isUserLoggedIn(state),
+    userEmail: User.selectors.getUserEmail(state),
   };
 };
 

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -86,7 +86,6 @@ class ProjectsFrame extends React.Component<Props, void> {
 
     const showPreview = deployment.url && params.view !== 'log';
 
-    // TODO: check that isUserLoggedIn is enough authentication
     return (
       <div className={styles['preview-container']}>
         <PreviewDialog
@@ -96,7 +95,7 @@ class ProjectsFrame extends React.Component<Props, void> {
           preview={preview}
           buildLogSelected={!showPreview}
           highlightComment={params.commentId}
-          authenticatedUser={isUserLoggedIn}
+          isAuthenticatedUser={isUserLoggedIn}
         />
         <iframe className={styles.preview} src={showPreview ? deployment.url : getBuildLogURL(deployment.id)} />
       </div>

--- a/src/js/components/deployment-view/preview-dialog.tsx
+++ b/src/js/components/deployment-view/preview-dialog.tsx
@@ -20,6 +20,7 @@ interface Props {
   deployment: Deployment;
   preview: Preview;
   isAuthenticatedUser: boolean;
+  userEmail?: string;
   highlightComment?: string;
   className?: string;
 }
@@ -57,6 +58,7 @@ class PreviewDialog extends React.Component<Props, State> {
       highlightComment,
       preview,
       isAuthenticatedUser,
+      userEmail,
     } = this.props;
     const { dialogOpen } = this.state;
 
@@ -89,12 +91,12 @@ class PreviewDialog extends React.Component<Props, State> {
             isAuthenticatedUser={isAuthenticatedUser}
           />
         )}
-        {dialogOpen /* TODO: get email from user auth if available */ && (
+        {dialogOpen && (
           <NewCommentForm
             initialValues={{
               deployment: deployment.id,
               name: getValue('commentName'),
-              email: getValue('commentEmail'),
+              email: userEmail || getValue('commentEmail'),
             }}
           />
         )}

--- a/src/js/components/deployment-view/preview-dialog.tsx
+++ b/src/js/components/deployment-view/preview-dialog.tsx
@@ -19,7 +19,7 @@ interface Props {
   commit: Commit;
   deployment: Deployment;
   preview: Preview;
-  authenticatedUser: boolean;
+  isAuthenticatedUser: boolean;
   highlightComment?: string;
   className?: string;
 }
@@ -56,7 +56,7 @@ class PreviewDialog extends React.Component<Props, State> {
       deployment,
       highlightComment,
       preview,
-      authenticatedUser,
+      isAuthenticatedUser,
     } = this.props;
     const { dialogOpen } = this.state;
 
@@ -69,7 +69,7 @@ class PreviewDialog extends React.Component<Props, State> {
           isOpen={dialogOpen}
           onToggleOpen={this.handleToggleOpen}
           buildLogSelected={buildLogSelected}
-          authenticatedUser={authenticatedUser}
+          isAuthenticatedUser={isAuthenticatedUser}
         />
         {dialogOpen && (
           <CommitSummary
@@ -78,7 +78,7 @@ class PreviewDialog extends React.Component<Props, State> {
             commit={commit}
             deployment={deployment}
             preview={preview}
-            authenticatedUser={authenticatedUser}
+            isAuthenticatedUser={isAuthenticatedUser}
           />
         )}
         {dialogOpen && deployment.comments && !isFetchError(deployment.comments) && deployment.comments.length > 0 && (
@@ -86,7 +86,7 @@ class PreviewDialog extends React.Component<Props, State> {
             className={styles['commit-list']}
             commentIds={deployment.comments}
             highlightComment={highlightComment}
-            authenticatedUser={authenticatedUser}
+            isAuthenticatedUser={isAuthenticatedUser}
           />
         )}
         {dialogOpen /* TODO: get email from user auth if available */ && (


### PR DESCRIPTION
If a user is logged in to Minard, their account email address will be pre-filled into the comment form in the Deployment View. If the user is not logged in, falls back to credentials stores in cookies.

Since we do not currently get the user's name from Auth0, this does not affect the display name for comments—that information is still stored/retrieved from cookies.

One possible improvement on this is to make the email address not editable and show their Gravatar if the user is logged in.

TODO:
- [ ] Merge #219 and base this onto master