### PR TITLE
Fall back to deployment-only streaming API if not logged in

### DIFF
--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 
 // require global styles
 require('font-awesome/css/font-awesome.css');
@@ -12,19 +13,15 @@ import StreamingAPIHandler from './streaming-api-handler';
 
 const styles = require('./app.scss');
 
-interface PassedProps {
-  location: any;
-  route: any;
-  params: {
-    deploymentId?: string;
-    commitHash?: string;
-    branchId?: string;
-    projectId?: string;
-    commentId?: string;
-    view?: string;
-    teamToken?: string;
-    show?: string;
-  };
+interface Params {
+  deploymentId?: string;
+  commitHash?: string;
+  branchId?: string;
+  projectId?: string;
+  commentId?: string;
+  view?: string;
+  teamToken?: string;
+  show?: string;
 }
 
 interface GeneratedStateProps {
@@ -35,7 +32,7 @@ interface GeneratedDispatchProps {
   setSelected: (project: string | null, branch: string | null, showAll: boolean) => void;
 }
 
-type Props = PassedProps & GeneratedDispatchProps & GeneratedStateProps;
+type Props = RouteComponentProps<Params, {}> & GeneratedDispatchProps & GeneratedStateProps;
 
 class App extends React.Component<Props, void> {
   public componentDidMount() {
@@ -67,14 +64,13 @@ const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
   team: User.selectors.getTeam(state),
 });
 
-
 const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
   setSelected: (project: string | null, branch: string | null, showAll: boolean) => {
     dispatch(Selected.actions.setSelected(project, branch, showAll));
   },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
   mapStateToProps,
   mapDispatchToProps,
 )(App);

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -6,6 +6,8 @@ require('font-awesome/css/font-awesome.css');
 import './styles.scss';
 
 import Selected from '../modules/selected';
+import User, { Team } from '../modules/user';
+import { StateTree } from '../reducers';
 import StreamingAPIHandler from './streaming-api-handler';
 
 const styles = require('./app.scss');
@@ -13,14 +15,27 @@ const styles = require('./app.scss');
 interface PassedProps {
   location: any;
   route: any;
-  params: any;
+  params: {
+    deploymentId?: string;
+    commitHash?: string;
+    branchId?: string;
+    projectId?: string;
+    commentId?: string;
+    view?: string;
+    teamToken?: string;
+    show?: string;
+  };
+}
+
+interface GeneratedStateProps {
+  team?: Team;
 }
 
 interface GeneratedDispatchProps {
   setSelected: (project: string | null, branch: string | null, showAll: boolean) => void;
 }
 
-type Props = PassedProps & GeneratedDispatchProps;
+type Props = PassedProps & GeneratedDispatchProps & GeneratedStateProps;
 
 class App extends React.Component<Props, void> {
   public componentDidMount() {
@@ -37,16 +52,21 @@ class App extends React.Component<Props, void> {
   }
 
   public render() {
-    const { children } = this.props;
+    const { children, team, params: { deploymentId, commitHash } } = this.props;
 
     return (
       <div id="minard-app" className={styles.app}>
-        <StreamingAPIHandler />
+        <StreamingAPIHandler team={team} deploymentId={deploymentId} commitHash={commitHash} />
         {children}
       </div>
     );
   }
 }
+
+const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
+  team: User.selectors.getTeam(state),
+});
+
 
 const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
   setSelected: (project: string | null, branch: string | null, showAll: boolean) => {
@@ -54,4 +74,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   },
 });
 
-export default connect<{}, GeneratedDispatchProps, PassedProps>(() => ({}), mapDispatchToProps)(App);
+export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(App);

--- a/src/js/components/branch-view/index.tsx
+++ b/src/js/components/branch-view/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 
 import Branches, { Branch } from '../../modules/branches';
 import Commits, { Commit } from '../../modules/commits';
@@ -14,11 +15,9 @@ import CommitList from './commit-list';
 
 const styles = require('./index.scss');
 
-interface PassedProps {
-  params: {
-    branchId: string;
-    projectId: string;
-  };
+interface Params {
+  branchId: string;
+  projectId: string;
 }
 
 interface GeneratedStateProps {
@@ -33,7 +32,9 @@ interface GeneratedDispatchProps {
   loadCommits: (id: string, count?: number, until?: number) => void;
 }
 
-class BranchView extends React.Component<GeneratedStateProps & PassedProps & GeneratedDispatchProps, StateTree> {
+type Props = GeneratedStateProps & RouteComponentProps<Params, {}> & GeneratedDispatchProps;
+
+class BranchView extends React.Component<Props, StateTree> {
   public componentWillMount() {
     const { loadBranch, loadCommits } = this.props;
     const { branchId } = this.props.params;
@@ -42,7 +43,7 @@ class BranchView extends React.Component<GeneratedStateProps & PassedProps & Gen
     loadCommits(branchId, 10);
   }
 
-  public componentWillReceiveProps(nextProps: GeneratedStateProps & PassedProps & GeneratedDispatchProps) {
+  public componentWillReceiveProps(nextProps: Props) {
     const { loadBranch, loadCommits } = this.props;
     const { branchId } = nextProps.params;
 
@@ -111,7 +112,7 @@ class BranchView extends React.Component<GeneratedStateProps & PassedProps & Gen
   }
 }
 
-const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStateProps => {
+const mapStateToProps = (state: StateTree, ownProps: RouteComponentProps<Params, {}>): GeneratedStateProps => {
   const { projectId, branchId } = ownProps.params;
   const project = Projects.selectors.getProject(state, projectId);
   const branch = Branches.selectors.getBranch(state, branchId);
@@ -130,7 +131,7 @@ const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStat
   };
 };
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
   mapStateToProps,
   {
     loadBranch: Branches.actions.loadBranch,

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -46,7 +46,7 @@ interface GeneratedDispatchProps {
 
 type Props = PassedProps & GeneratedStateProps & GeneratedDispatchProps;
 
-class ProjectsFrame extends React.Component<Props, void> {
+class DeploymentView extends React.Component<Props, void> {
   constructor(props: Props) {
     super(props);
 
@@ -169,4 +169,4 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
 export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
   mapStateToProps,
   mapDispatchToProps,
-)(ProjectsFrame);
+)(DeploymentView);

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 import { push } from 'react-router-redux';
 
 import Commits, { Commit } from '../../modules/commits';
@@ -20,15 +21,11 @@ const getBuildLogURL = process.env.CHARLES ?
 
 const styles = require('./index.scss');
 
-interface PassedProps {
-  location: any;
-  route: any;
-  params: {
-    commitHash: string;
-    deploymentId: string;
-    commentId?: string;
-    view?: string;
-  };
+interface Params {
+  commitHash: string;
+  deploymentId: string;
+  commentId?: string;
+  view?: string;
 }
 
 interface GeneratedStateProps {
@@ -44,7 +41,7 @@ interface GeneratedDispatchProps {
   redirectToApp: () => void;
 }
 
-type Props = PassedProps & GeneratedStateProps & GeneratedDispatchProps;
+type Props = RouteComponentProps<Params, {}> & GeneratedStateProps & GeneratedDispatchProps;
 
 class DeploymentView extends React.Component<Props, void> {
   constructor(props: Props) {
@@ -139,7 +136,7 @@ class DeploymentView extends React.Component<Props, void> {
   }
 }
 
-const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStateProps => {
+const mapStateToProps = (state: StateTree, ownProps: RouteComponentProps<Params, {}>): GeneratedStateProps => {
   const { deploymentId } = ownProps.params;
   const preview = Previews.selectors.getPreview(state, deploymentId);
   let commit: Commit | FetchError | undefined;
@@ -166,7 +163,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   redirectToApp: () => { dispatch(push('/')); },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
   mapStateToProps,
   mapDispatchToProps,
 )(DeploymentView);

--- a/src/js/components/login-view/index.tsx
+++ b/src/js/components/login-view/index.tsx
@@ -3,6 +3,7 @@ import Auth0Lock from 'auth0-lock';
 import * as moment from 'moment';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 import { push } from 'react-router-redux';
 
 import { clearStoredCredentials, storeCredentials } from '../../api/auth';
@@ -28,13 +29,11 @@ interface GeneratedDispatchProps {
   loadTeamInformation: () => void;
 }
 
-interface PassedProps {
-  params: {
-    returnPath?: string;
-  };
+interface Params {
+  returnPath?: string;
 }
 
-type Props = GeneratedStateProps & GeneratedDispatchProps & PassedProps;
+type Props = GeneratedStateProps & GeneratedDispatchProps & RouteComponentProps<Params, {}>;
 
 interface State {
   loadingStatus: LoadingStatus;
@@ -194,4 +193,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   loadTeamInformation: () => { dispatch(User.actions.loadTeamInformation()); },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(LoginView);
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(LoginView);

--- a/src/js/components/project-view/index.tsx
+++ b/src/js/components/project-view/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 
 import Activities, { Activity } from '../../modules/activities';
 import Branches, { Branch } from '../../modules/branches';
@@ -17,11 +18,9 @@ import ProjectSettingsDialog from './project-settings-dialog';
 
 const styles = require('./index.scss');
 
-interface PassedProps {
-  params: {
-    projectId: string;
-    show?: string;
-  };
+interface Params {
+  projectId: string;
+  show?: string;
 }
 
 interface GeneratedStateProps {
@@ -38,7 +37,9 @@ interface GeneratedDispatchProps {
   loadBranches: (id: string) => void;
 }
 
-class ProjectView extends React.Component<PassedProps & GeneratedStateProps & GeneratedDispatchProps, void> {
+type Props = RouteComponentProps<Params, {}> & GeneratedStateProps & GeneratedDispatchProps;
+
+class ProjectView extends React.Component<Props, void> {
   public componentWillMount() {
     const { loadProject, loadActivities, loadBranches } = this.props;
     const { projectId } = this.props.params;
@@ -48,7 +49,7 @@ class ProjectView extends React.Component<PassedProps & GeneratedStateProps & Ge
     loadActivities(projectId, 10);
   }
 
-  public componentWillReceiveProps(nextProps: PassedProps & GeneratedStateProps & GeneratedDispatchProps) {
+  public componentWillReceiveProps(nextProps: Props) {
     const { loadProject, loadActivities, loadBranches } = this.props;
     const { projectId } = nextProps.params;
 
@@ -137,7 +138,7 @@ class ProjectView extends React.Component<PassedProps & GeneratedStateProps & Ge
   }
 }
 
-const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStateProps => {
+const mapStateToProps = (state: StateTree, ownProps: RouteComponentProps<Params, {}>): GeneratedStateProps => {
   const { projectId } = ownProps.params;
   const project = Projects.selectors.getProject(state, projectId);
   const isLoadingActivities = Requests.selectors.isLoadingActivitiesForProject(state, projectId);
@@ -178,7 +179,7 @@ const dispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
   loadBranches: (id: string) => { dispatch(Branches.actions.loadBranchesForProject(id)); },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
   mapStateToProps,
   dispatchToProps,
 )(ProjectView);

--- a/src/js/components/signup-view/index.tsx
+++ b/src/js/components/signup-view/index.tsx
@@ -2,6 +2,7 @@ import * as Auth0 from 'auth0-js';
 import * as moment from 'moment';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 import { push } from 'react-router-redux';
 
 import { storeCredentials } from '../../api/auth';
@@ -25,13 +26,11 @@ interface GeneratedStateProps {
   error?: string;
 }
 
-interface PassedProps {
-  params: {
-    teamToken?: string;
-  };
+interface Params {
+  teamToken?: string;
 }
 
-type Props = GeneratedDispatchProps & PassedProps & GeneratedStateProps;
+type Props = GeneratedDispatchProps & RouteComponentProps<Params, {}> & GeneratedStateProps;
 
 interface State {
   loadingStatus: LoadingStatus;
@@ -214,7 +213,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   setUserEmail: (email: string, expiresAt) => { dispatch(User.actions.setUserEmail(email, expiresAt)); },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
   mapStateToProps,
   mapDispatchToProps,
 )(SignupView);

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -464,7 +464,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, {}>(
   mapStateToProps,
   mapDispatchToProps,
 )(StreamingAPIHandler);

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -367,16 +367,18 @@ class StreamingAPIHandler extends React.Component<Props, void> {
   public componentWillReceiveProps(nextProps: Props) {
     const { team, setConnectionState } = this.props;
 
-    // User logged in
-    if (streamingAPIUrl && !team && nextProps.team) {
-      this.restartConnection(nextProps.team.id);
-    }
+    if (streamingAPIUrl) {
+      // User logged in or changed teams
+      if (nextProps.team && (!team || nextProps.team.id !== team.id)) {
+        this.restartConnection(nextProps.team.id);
+      }
 
-    // User logged out
-    if (team && !nextProps.team) {
-      setConnectionState(ConnectionState.INITIAL_CONNECT);
-      this._source.close();
-      this._source = null;
+      // User logged out
+      if (team && !nextProps.team) {
+        setConnectionState(ConnectionState.INITIAL_CONNECT);
+        this._source.close();
+        this._source = null;
+      }
     }
   }
 

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -22,8 +22,7 @@ import Commits, { Commit } from '../modules/commits';
 import Deployments, { Deployment, DeploymentStatus } from '../modules/deployments';
 import Projects, { Project, ProjectUser } from '../modules/projects';
 import Streaming, { ConnectionState } from '../modules/streaming';
-import User, { Team } from '../modules/user';
-import { StateTree } from '../reducers';
+import { Team } from '../modules/user';
 
 declare const EventSource: any;
 
@@ -52,20 +51,13 @@ interface GeneratedDispatchProps {
   removeBranchFromProject: (id: string, branch: string) => void;
 }
 
-interface GeneratedStateProps {
-  team?: Team;
-}
-
 interface PassedProps {
-  location: any;
-  route: any;
-  params: {
-    commitHash?: string;
-    deploymentId?: string;
-  };
+  team?: Team;
+  commitHash?: string;
+  deploymentId?: string;
 }
 
-type Props = PassedProps & GeneratedDispatchProps & GeneratedStateProps;
+type Props = PassedProps & GeneratedDispatchProps;
 
 // Streaming API types
 interface EventSourceEvent {
@@ -353,7 +345,7 @@ class StreamingAPIHandler extends React.Component<Props, void> {
   }
 
   public componentWillMount() {
-    const { team, params: { deploymentId, commitHash } } = this.props;
+    const { team, deploymentId, commitHash } = this.props;
 
     if (streamingAPIUrl) {
       if (team) {
@@ -393,10 +385,6 @@ class StreamingAPIHandler extends React.Component<Props, void> {
     return <span />;
   }
 }
-
-const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
-  team: User.selectors.getTeam(state),
-});
 
 const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
   // Activities
@@ -464,7 +452,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, {}>(
-  mapStateToProps,
+export default connect<{}, GeneratedDispatchProps, PassedProps>(
+  () => ({}),
   mapDispatchToProps,
 )(StreamingAPIHandler);

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -320,7 +320,7 @@ class StreamingAPIHandler extends React.Component<Props, void> {
         this._source.close();
         this._source = null;
 
-        setTimeout(this.restartConnection, 5000, teamId); // TODO: smarter retry logic?
+        setTimeout(this.restartConnection, 5000, { teamId }); // TODO: smarter retry logic?
       }
     }, false);
     this._source.addEventListener('open', () => {
@@ -370,7 +370,7 @@ class StreamingAPIHandler extends React.Component<Props, void> {
     if (streamingAPIUrl) {
       // User logged in or changed teams
       if (nextProps.team && (!team || nextProps.team.id !== team.id)) {
-        this.restartConnection(nextProps.team.id);
+        this.restartConnection({ teamId: nextProps.team.id });
       }
 
       // User logged out

--- a/src/js/components/team-projects-view/index.tsx
+++ b/src/js/components/team-projects-view/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 
 import Activities, { Activity } from '../../modules/activities';
 import { FetchError } from '../../modules/errors';
@@ -14,10 +15,8 @@ import ProjectsSection from './projects-section';
 
 const styles = require('./index.scss');
 
-interface PassedProps {
-  params: {
-    show?: string;
-  };
+interface Params {
+  show?: string;
 }
 
 interface GeneratedStateProps {
@@ -34,7 +33,7 @@ interface GeneratedDispatchProps {
   loadActivities: (teamId: string, count: number, until?: number) => void;
 }
 
-type Props = GeneratedStateProps & GeneratedDispatchProps & PassedProps;
+type Props = GeneratedStateProps & GeneratedDispatchProps & RouteComponentProps<Params, {}>;
 
 class TeamProjectsView extends React.Component<Props, void> {
   constructor(props: Props) {
@@ -102,7 +101,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
   },
 });
 
-export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(
+export default connect<GeneratedStateProps, GeneratedDispatchProps, RouteComponentProps<Params, {}>>(
   mapStateToProps,
   mapDispatchToProps,
 )(TeamProjectsView);


### PR DESCRIPTION
If a user is not logged in, the realtime component will connect to `/events/deployment/<deploymentID>?sha=<commitHash>` instead of `/events/<teamID>?token=<accessToken>`.