### PR TITLE
Fetch build log in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
+    "ansi-to-html": "^0.6.0",
     "auth0-js": "^8.5.0",
     "auth0-lock": "^10.14.0",
     "classnames": "^2.2.5",

--- a/src/js/api/index.ts
+++ b/src/js/api/index.ts
@@ -28,7 +28,8 @@ interface Error {
 }
 
 function generateErrorObject(errorResponse: any) {
-  let error: string = errorResponse.message || 'An error occurred';
+  let error: string = errorResponse.message ||
+    (typeof errorResponse === 'string' ? errorResponse : 'An error occurred');
   let details: string = '';
 
   if (errorResponse && errorResponse.errors && errorResponse.errors.length > 0) {

--- a/src/js/api/index.ts
+++ b/src/js/api/index.ts
@@ -52,14 +52,14 @@ function generateErrorObject(errorResponse: any) {
  * This method will overwrite the Authorization header if an access token exists.
  */
 function connectToApi<ResponseType>(path: string, options?: RequestInit): Promise<ApiResult<ResponseType>> {
-  const combinedOptions = {
+  const combinedOptions: RequestInit = {
     ...defaultOptions,
     ...options,
   };
 
   const accessToken = getAccessToken();
   if (accessToken) {
-    (combinedOptions.headers as any).Authorization = `Bearer ${accessToken}`;
+    combinedOptions.headers.Authorization = `Bearer ${accessToken}`;
   }
 
   return fetch(`${host}${path}`, combinedOptions)
@@ -68,9 +68,9 @@ function connectToApi<ResponseType>(path: string, options?: RequestInit): Promis
         json,
         response,
       })) as Promise<{ json: any, response: Response }>,
-    ).then(({ json, response }) => {
+    ).then<{ response: any }>(({ json, response }) => {
       if (response.ok) {
-        return json;
+        return { response: json };
       }
 
       if (response.status === 401 || response.status === 403) {
@@ -78,9 +78,7 @@ function connectToApi<ResponseType>(path: string, options?: RequestInit): Promis
       }
 
       return Promise.reject(json);
-    }).then(
-      json => ({ response: json }),
-    ).catch(errorResponse => {
+    }).catch(errorResponse => {
       logMessage('Error while calling API', { path, errorResponse }, 'info');
 
       return generateErrorObject(errorResponse);

--- a/src/js/api/static-json.ts
+++ b/src/js/api/static-json.ts
@@ -4,8 +4,6 @@ import { Api, ApiEntityResponse, ApiPreviewResponse, ApiResult, ApiTeam } from '
 
 console.log('Using bundled JSON files'); // tslint:disable-line:no-console
 
-export const getBuildLogURL = (_deploymentId: string): string => '#';
-
 const activitiesJSON = require('file-loader!../../../json/activities.json');
 const allProjectsJSON = require('file-loader!../../../json/projects.json');
 const projectJSON: { [id: string]: string } = {
@@ -88,6 +86,7 @@ const Commit = {
 
 const Deployment = {
   fetch: (id: string): Promise<ApiResult<ApiEntityResponse>> => fetchFile(deploymentJSON[id]),
+  fetchBuildLog: (_id: string): Promise<ApiResult<string>> => Promise.resolve({ response: 'Build log...' }),
 };
 
 const Preview = {

--- a/src/js/api/types.ts
+++ b/src/js/api/types.ts
@@ -25,6 +25,7 @@ export interface Api {
   };
   Deployment: {
     fetch: (id: string) => Promise<ApiResult<ApiEntityResponse>>;
+    fetchBuildLog: (id: string) => Promise<ApiResult<string>>;
   };
   Preview: {
     fetch: (id: string, commitHash: string) => Promise<ApiResult<ApiPreviewResponse>>;

--- a/src/js/components/branch-view/commit-list.tsx
+++ b/src/js/components/branch-view/commit-list.tsx
@@ -41,7 +41,9 @@ const CommitList = ({ commits, isLoading, allLoaded, loadCommits }: Props) => {
   return (
     <section className={classNames(styles['commit-list'], 'container')}>
       <FlipMove enterAnimation="fade" leaveAnimation="fade">
-        {commits.map((commit, i) => <CommitRow key={(commit && commit.id) || i} commit={commit} />)}
+        {commits.map((commit, i) => (
+          <CommitRow key={(commit && commit.id) || i} commit={isFetchError(commit) ? undefined : commit} />
+        ))}
       </FlipMove>
       {isLoading && <LoadingIcon className={styles.loading} center />}
       {!isLoading && !allLoaded && lastCommit && !isFetchError(lastCommit) && (

--- a/src/js/components/branch-view/commit-row.tsx
+++ b/src/js/components/branch-view/commit-row.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { Commit } from '../../modules/commits';
 import Deployments, { Deployment, isSuccessful } from '../../modules/deployments';
-import { FetchError, isFetchError } from '../../modules/errors';
+import { isFetchError } from '../../modules/errors';
 import { StateTree } from '../../reducers';
 
 import BuildStatus from '../common/build-status';
@@ -14,20 +14,27 @@ import SingleCommit from '../common/single-commit';
 const styles = require('./commit-row.scss');
 
 interface PassedProps {
-  commit?: Commit | FetchError;
+  commit?: Commit;
 }
 
 interface GeneratedProps {
   deployment?: Deployment;
 }
 
-const getScreenshotOrBuildBadge = (deployment?: Deployment, commit?: FetchError | Commit) => {
+const getScreenshotOrBuildBadge = (deployment?: Deployment, commit?: Commit) => {
   if (!deployment || !isSuccessful(deployment)) {
-    return <BuildStatus className={styles['build-status']} deployment={deployment} latest={false} />;
+    return (
+      <BuildStatus
+        className={styles['build-status']}
+        deployment={deployment}
+        commit={commit}
+        latest={false}
+      />
+    );
   }
 
   return (
-    <MinardLink preview={deployment} commit={isFetchError(commit) ? undefined : commit}>
+    <MinardLink preview={deployment} commit={commit}>
       <img className={styles.screenshot} src={deployment.screenshot} />
     </MinardLink>
   );
@@ -39,7 +46,7 @@ const CommitRow = ({ commit, deployment }: PassedProps & GeneratedProps) => (
       {getScreenshotOrBuildBadge(deployment, commit)}
     </div>
     <div className={classNames(styles['commit-container'], 'col-xs-10')}>
-      <MinardLink className={styles.commit} preview={deployment} commit={isFetchError(commit) ? undefined : commit}>
+      <MinardLink className={styles.commit} preview={deployment} commit={commit}>
         <SingleCommit commit={commit} deployment={deployment} />
       </MinardLink>
     </div>
@@ -49,7 +56,7 @@ const CommitRow = ({ commit, deployment }: PassedProps & GeneratedProps) => (
 const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedProps => {
   const { commit } = ownProps;
 
-  if (commit && !isFetchError(commit) && commit.deployment) {
+  if (commit && commit.deployment) {
     const deploymentOrError = Deployments.selectors.getDeployment(state, commit.deployment);
 
     return {

--- a/src/js/components/common/build-status.tsx
+++ b/src/js/components/common/build-status.tsx
@@ -4,31 +4,32 @@ import * as ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import Icon = require('react-fontawesome');
 
 import { logMessage } from '../../logger';
+import { Commit } from '../../modules/commits';
 import { Deployment, DeploymentStatus } from '../../modules/deployments';
-import { FetchError, isFetchError } from '../../modules/errors';
 import MinardLink from './minard-link';
 
 const styles = require('./build-status.scss');
 
 interface PassedProps {
-  deployment?: Deployment | FetchError;
+  deployment?: Deployment;
+  commit?: Commit;
   className?: string;
   latest?: boolean;
 }
 
-const BuildStatus = ({ className, deployment, latest }: PassedProps) => {
+const BuildStatus = ({ className, commit, deployment, latest }: PassedProps) => {
   let content: JSX.Element | null = null;
 
   // TODO: Link to build tab of Deployment View instead
 
-  if (deployment && !isFetchError(deployment)) {
+  if (deployment && commit) {
     switch (deployment.status) {
       case DeploymentStatus.Success:
         content = null;
         break;
       case DeploymentStatus.Canceled:
         content = (
-          <MinardLink preview={deployment} buildLog openInNewWindow>
+          <MinardLink preview={deployment} commit={commit} buildLog openInNewWindow>
             <div key="canceled" className={classNames(styles.box, styles.error)}>
               <Icon name="times" className={styles.icon} />
               {latest ? <span>Latest build canceled</span> : <span>Build canceled</span>}
@@ -38,7 +39,7 @@ const BuildStatus = ({ className, deployment, latest }: PassedProps) => {
         break;
       case DeploymentStatus.Failed:
         content = (
-          <MinardLink preview={deployment} buildLog openInNewWindow>
+          <MinardLink preview={deployment} commit={commit} buildLog openInNewWindow>
             <div key="failed" className={classNames(styles.box, styles.error)}>
               <Icon name="times" className={styles.icon} />
               {latest ? <span>Latest build failed</span> : <span>Build failed</span>}
@@ -49,7 +50,7 @@ const BuildStatus = ({ className, deployment, latest }: PassedProps) => {
       case DeploymentStatus.Pending:
       case DeploymentStatus.Running:
         content = (
-          <MinardLink preview={deployment} buildLog openInNewWindow>
+          <MinardLink preview={deployment} commit={commit} buildLog openInNewWindow>
             <div key="running" className={classNames(styles.box, styles.building)}>
               <Icon name="circle-o-notch" spin className={styles.icon} />
               Generating preview

--- a/src/js/components/common/build-status.tsx
+++ b/src/js/components/common/build-status.tsx
@@ -6,10 +6,7 @@ import Icon = require('react-fontawesome');
 import { logMessage } from '../../logger';
 import { Deployment, DeploymentStatus } from '../../modules/deployments';
 import { FetchError, isFetchError } from '../../modules/errors';
-
-const getBuildLogURL = process.env.CHARLES ?
-  require('../../api').getBuildLogURL :
-  require('../../api/static-json').getBuildLogURL;
+import MinardLink from './minard-link';
 
 const styles = require('./build-status.scss');
 
@@ -31,33 +28,33 @@ const BuildStatus = ({ className, deployment, latest }: PassedProps) => {
         break;
       case DeploymentStatus.Canceled:
         content = (
-          <a href={getBuildLogURL(deployment.id)} target="_blank">
+          <MinardLink preview={deployment} buildLog openInNewWindow>
             <div key="canceled" className={classNames(styles.box, styles.error)}>
               <Icon name="times" className={styles.icon} />
               {latest ? <span>Latest build canceled</span> : <span>Build canceled</span>}
             </div>
-          </a>
+          </MinardLink>
         );
         break;
       case DeploymentStatus.Failed:
         content = (
-          <a href={getBuildLogURL(deployment.id)} target="_blank">
+          <MinardLink preview={deployment} buildLog openInNewWindow>
             <div key="failed" className={classNames(styles.box, styles.error)}>
               <Icon name="times" className={styles.icon} />
               {latest ? <span>Latest build failed</span> : <span>Build failed</span>}
             </div>
-          </a>
+          </MinardLink>
         );
         break;
       case DeploymentStatus.Pending:
       case DeploymentStatus.Running:
         content = (
-          <a href={getBuildLogURL(deployment.id)} target="_blank">
+          <MinardLink preview={deployment} buildLog openInNewWindow>
             <div key="running" className={classNames(styles.box, styles.building)}>
               <Icon name="circle-o-notch" spin className={styles.icon} />
               Generating preview
             </div>
-          </a>
+          </MinardLink>
         );
         break;
       default:

--- a/src/js/components/common/build-status.tsx
+++ b/src/js/components/common/build-status.tsx
@@ -20,8 +20,6 @@ interface PassedProps {
 const BuildStatus = ({ className, commit, deployment, latest }: PassedProps) => {
   let content: JSX.Element | null = null;
 
-  // TODO: Link to build tab of Deployment View instead
-
   if (deployment && commit) {
     switch (deployment.status) {
       case DeploymentStatus.Success:

--- a/src/js/components/deployment-view/build-log.scss
+++ b/src/js/components/deployment-view/build-log.scss
@@ -1,0 +1,11 @@
+.build-log {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  overflow: auto;
+  border: 0;
+  z-index: 2;
+  background-color: white;
+}

--- a/src/js/components/deployment-view/build-log.scss
+++ b/src/js/components/deployment-view/build-log.scss
@@ -1,4 +1,6 @@
-.build-log {
+@import '../mixins';
+
+.frame {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -8,4 +10,13 @@
   border: 0;
   z-index: 2;
   background-color: white;
+  padding: 4rem 1rem 1rem 4rem;
+
+  @media (max-width: 640px) {
+    padding: 4rem 1rem 1rem 2rem;
+  }
+}
+
+.build-log {
+  @include nitti;
 }

--- a/src/js/components/deployment-view/build-log.tsx
+++ b/src/js/components/deployment-view/build-log.tsx
@@ -1,4 +1,6 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
+const Convert = require('ansi-to-html');
 
 import API from '../../api';
 import { Deployment } from '../../modules/deployments';
@@ -6,6 +8,13 @@ import { Deployment } from '../../modules/deployments';
 import Spinner from '../common/spinner';
 
 const styles = require('./build-log.scss');
+
+const convert = new Convert({
+  fg: '#000',
+  bg: '#fff',
+  newline: true,
+  escapeXML: true,
+});
 
 interface PassedProps {
   deployment: Deployment;
@@ -85,10 +94,19 @@ class BuildLog extends React.Component<Props, State> {
       return <Spinner />;
     }
 
+    if (error) {
+      return (
+        <div className={classNames(styles.frame, styles.error)}>
+          Error: {error}
+        </div>
+      );
+    }
+
     return (
-      <div className={styles['build-log']}>
-        {error ? `Error: ${error}` : <pre>{log}</pre>}
-      </div>
+      <div
+        className={classNames(styles.frame, styles['build-log'])}
+        dangerouslySetInnerHTML={{ __html: convert.toHtml(log) }}
+      />
     );
   }
 }

--- a/src/js/components/deployment-view/build-log.tsx
+++ b/src/js/components/deployment-view/build-log.tsx
@@ -69,7 +69,7 @@ class BuildLog extends React.Component<Props, State> {
 
           this.setState({ error: result.error });
         } else {
-          this.setState({ log: result.response });
+          this.setState({ log: result.response, error: undefined });
         }
       });
   }

--- a/src/js/components/deployment-view/build-log.tsx
+++ b/src/js/components/deployment-view/build-log.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+
+import API from '../../api';
+import { Deployment } from '../../modules/deployments';
+
+import Spinner from '../common/spinner';
+
+const styles = require('./build-log.scss');
+
+interface PassedProps {
+  deployment: Deployment;
+}
+
+interface State {
+  log?: string;
+  error?: string;
+}
+
+type Props = PassedProps;
+
+interface ErrorResponse {
+  error: string;
+  details?: string | undefined;
+  unauthorized?: boolean | undefined;
+}
+
+function isError(response: any): response is ErrorResponse {
+  return (response as ErrorResponse).error !== undefined;
+}
+
+class BuildLog extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      log: undefined,
+      error: undefined,
+    };
+
+    this.updateLog = this.updateLog.bind(this);
+  }
+
+  private intervalID?: any;
+  private refreshCadenceInMs = 5000;
+
+  public componentWillMount() {
+    const { deployment } = this.props;
+
+    this.updateLog(deployment.id);
+    this.intervalID = setInterval(this.updateLog, this.refreshCadenceInMs, deployment.id);
+  }
+
+  private updateLog(deploymentId: string) {
+    API.Deployment.fetchBuildLog(deploymentId)
+      .then(result => {
+        if (isError(result)) {
+          if (this.intervalID) {
+            clearInterval(this.intervalID);
+          }
+
+          this.setState({ error: result.error });
+        } else {
+          this.setState({ log: result.response });
+        }
+      });
+  }
+
+  public componentWillReceiveProps(nextProps: Props) {
+    const { deployment } = this.props;
+
+    if (deployment.id !== nextProps.deployment.id) {
+      if (this.intervalID) {
+        clearInterval(this.intervalID);
+      }
+
+      this.updateLog(nextProps.deployment.id);
+      this.intervalID = setInterval(this.updateLog, this.refreshCadenceInMs, nextProps.deployment.id);
+    }
+  }
+
+  public render() {
+    const { log, error } = this.state;
+
+    if (!log && !error) {
+      return <Spinner />;
+    }
+
+    return (
+      <div className={styles['build-log']}>
+        {error ? `Error: ${error}` : <pre>{log}</pre>}
+      </div>
+    );
+  }
+}
+
+export default BuildLog;

--- a/src/js/components/deployment-view/build-log.tsx
+++ b/src/js/components/deployment-view/build-log.tsx
@@ -4,7 +4,6 @@ const Convert = require('ansi-to-html');
 
 import API from '../../api';
 import { Deployment } from '../../modules/deployments';
-
 import Spinner from '../common/spinner';
 
 const styles = require('./build-log.scss');
@@ -59,6 +58,23 @@ class BuildLog extends React.Component<Props, State> {
     this.intervalID = setInterval(this.updateLog, this.refreshCadenceInMs, deployment.id);
   }
 
+  public componentWillReceiveProps(nextProps: Props) {
+    const { deployment } = this.props;
+
+    if (deployment.id !== nextProps.deployment.id) {
+      if (this.intervalID) {
+        clearInterval(this.intervalID);
+      }
+
+      this.updateLog(nextProps.deployment.id);
+      this.intervalID = setInterval(this.updateLog, this.refreshCadenceInMs, nextProps.deployment.id);
+    }
+  }
+
+  public componentWillUnmount() {
+    clearInterval(this.intervalID);
+  }
+
   private updateLog(deploymentId: string) {
     API.Deployment.fetchBuildLog(deploymentId)
       .then(result => {
@@ -72,19 +88,6 @@ class BuildLog extends React.Component<Props, State> {
           this.setState({ log: result.response, error: undefined });
         }
       });
-  }
-
-  public componentWillReceiveProps(nextProps: Props) {
-    const { deployment } = this.props;
-
-    if (deployment.id !== nextProps.deployment.id) {
-      if (this.intervalID) {
-        clearInterval(this.intervalID);
-      }
-
-      this.updateLog(nextProps.deployment.id);
-      this.intervalID = setInterval(this.updateLog, this.refreshCadenceInMs, nextProps.deployment.id);
-    }
   }
 
   public render() {

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -13,11 +13,8 @@ import { StateTree } from '../../reducers';
 import ErrorDialog from '../common/error-dialog';
 import Spinner from '../common/spinner';
 import Header from '../header';
+import BuildLog from './build-log';
 import PreviewDialog from './preview-dialog';
-
-const getBuildLogURL = process.env.CHARLES ?
-  require('../../api').getBuildLogURL :
-  require('../../api/static-json').getBuildLogURL;
 
 const styles = require('./index.scss');
 
@@ -130,7 +127,10 @@ class DeploymentView extends React.Component<Props, void> {
           isAuthenticatedUser={isUserLoggedIn}
           userEmail={userEmail}
         />
-        <iframe className={styles.preview} src={showPreview ? deployment.url : getBuildLogURL(deployment.id)} />
+        {showPreview ?
+          <iframe className={styles.preview} src={deployment.url} /> :
+          <BuildLog deployment={deployment} />
+        }
       </div>
     );
   }

--- a/src/js/components/project-view/branch-summary.tsx
+++ b/src/js/components/project-view/branch-summary.tsx
@@ -23,10 +23,19 @@ interface GeneratedProps {
   latestSuccessfulDeployment?: Deployment | FetchError;
   latestSuccessfullyDeployedCommit?: Commit | FetchError;
   deploymentForLatestCommit?: Deployment | FetchError;
+  latestCommit?: Commit | FetchError;
 }
 
-const BranchSummary = (props: PassedProps & GeneratedProps) => {
-  const { branch, latestSuccessfulDeployment, latestSuccessfullyDeployedCommit, deploymentForLatestCommit } = props;
+type Props = PassedProps & GeneratedProps;
+
+const BranchSummary = (props: Props) => {
+  const {
+    branch,
+    latestSuccessfulDeployment,
+    latestSuccessfullyDeployedCommit,
+    deploymentForLatestCommit,
+    latestCommit,
+  } = props;
   let commitContent: JSX.Element;
 
   if (!latestSuccessfullyDeployedCommit) {
@@ -74,7 +83,7 @@ const BranchSummary = (props: PassedProps & GeneratedProps) => {
           <BuildStatus
             className={styles['build-status']}
             deployment={isFetchError(deploymentForLatestCommit) ? undefined : deploymentForLatestCommit}
-            commit={isFetchError(latestSuccessfullyDeployedCommit) ? undefined : latestSuccessfullyDeployedCommit}
+            commit={isFetchError(latestCommit) ? undefined : latestCommit}
             latest={true}
           />
         </div>
@@ -107,8 +116,9 @@ const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedProp
   }
 
   let deploymentForLatestCommit: Deployment | FetchError | undefined;
+  let latestCommit: Commit | FetchError | undefined;
   if (branch.latestCommit) {
-    const latestCommit = Commits.selectors.getCommit(state, branch.latestCommit);
+    latestCommit = Commits.selectors.getCommit(state, branch.latestCommit);
     if (latestCommit && !isFetchError(latestCommit) && latestCommit.deployment) {
       deploymentForLatestCommit = Deployments.selectors.getDeployment(state, latestCommit.deployment);
     }
@@ -118,6 +128,7 @@ const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedProp
     latestSuccessfulDeployment,
     latestSuccessfullyDeployedCommit,
     deploymentForLatestCommit,
+    latestCommit,
   };
 };
 

--- a/src/js/components/project-view/branch-summary.tsx
+++ b/src/js/components/project-view/branch-summary.tsx
@@ -71,7 +71,12 @@ const BranchSummary = (props: PassedProps & GeneratedProps) => {
           <MinardLink branch={branch}>
             <div className={styles.title}>{branch.name}</div>
           </MinardLink>
-          <BuildStatus className={styles['build-status']} deployment={deploymentForLatestCommit} latest={true} />
+          <BuildStatus
+            className={styles['build-status']}
+            deployment={isFetchError(deploymentForLatestCommit) ? undefined : deploymentForLatestCommit}
+            commit={isFetchError(latestSuccessfullyDeployedCommit) ? undefined : latestSuccessfullyDeployedCommit}
+            latest={true}
+          />
         </div>
         <MinardLink branch={branch}>
           <div className={styles.description}>{branch.description}</div>

--- a/test/sagas.spec.ts
+++ b/test/sagas.spec.ts
@@ -48,6 +48,7 @@ const createApi = (): Api => {
     },
     Deployment: {
       fetch: (_id: string) => Promise.resolve(emptyResponse),
+      fetchBuildLog: (_id: string) => Promise.resolve({ response: '' }),
     },
     Preview: {
       fetch: (_id: string) => Promise.resolve(emptyResponse),

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,6 +169,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-to-html@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.0.tgz#719a6b5a9c11178fdb7faead28c604ea90cf8eed"
+  dependencies:
+    entities "^1.1.1"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -1931,7 +1937,7 @@ enhanced-resolve@^3.0.0, enhanced-resolve@^3.1.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 


### PR DESCRIPTION
Previously, the build log for deployments was fetched directly from minard-backend. This PR changes the Deployment View to fetch the content of the log from the server, convert the ANSI codes to HTML, and display it to the user. It also refreshes the log every 5 seconds to automatically update it. The downside is that it will re-fetch the log every 5 seconds even if the build has completed. A future improvement to this is to stream the contents instead of polling it.

TODO:
- [x] Merge #229 and rebase this onto master