### PR TITLE
Add permanent links for latest deployment per branch

### DIFF
--- a/src/js/components/branch-view/index.tsx
+++ b/src/js/components/branch-view/index.tsx
@@ -109,8 +109,8 @@ class BranchView extends React.Component<Props, StateTree> {
       return this.getErrorContent(branch);
     }
 
-    // redirect to latest deployment
-    if (redirect === 'latest') {
+    // Will redirect to latest deployment once everything has been loaded. Show spinner until then.
+    if (redirect === 'latest' && branch.latestSuccessfullyDeployedCommit) {
       return this.getLoadingContent();
     }
 

--- a/src/js/routes.tsx
+++ b/src/js/routes.tsx
@@ -15,7 +15,7 @@ export default (
     <IndexRedirect to="/projects" />
     <Route component={ProjectsFrame}>
       <Route path="projects(/:show)" component={TeamProjectsView} />
-      <Route path="project/:projectId/branch/:branchId" component={BranchView} />
+      <Route path="project/:projectId/branch/:branchId(/:redirect)" component={BranchView} />
       <Route path="project/:projectId(/:show)" component={ProjectView} />
     </Route>
     <Route path="preview/:commitHash/:deploymentId" component={DeploymentView}>


### PR DESCRIPTION
This PR adds support for permanent URLs for the latest deployment per branch in a project. The URLs are of the form:

```
https://minard.io/project/<PROJECTID>/branch/<BRANCHNAME>/latest
```

We'll want to add such links for raw deployments (i.e. in the backend) at some point, but this should cover most use cases.

We'll add links to this URL to the UI in a separate PR.

The main Minard UI is shown briefly while loading the required information for the deployment. Fixing it is a bit difficult, so unless people feel it's really necessary, I'd leave this aspect as is.

TODO:
- [x] Add support for links
- [x] Base this onto master once #232 is merged