### PR TITLE
Fix mock API usage

### DIFF
--- a/src/js/api/static-json.ts
+++ b/src/js/api/static-json.ts
@@ -35,23 +35,22 @@ const newProjectJSON = require('file-loader!../../../json/new-project.json');
 const editedProjectJSON = require('file-loader!../../../json/edited-project.json');
 const previewJSON = require('file-loader!../../../json/preview.json');
 
-function fetchFile(url: string) {
-  return fetch(url, { credentials: 'same-origin' })
-    .then(
-      response => response.json().then(json => ({
-        json,
-        response,
-      })) as Promise<{ json: any, response: any}>,
-    ).then(
-      ({ json, response }) => response.ok ? json : Promise.reject(json),
-    ).then(
-      json => ({ response: json }),
-    ).catch(
-      error => ({
-        error: error.message || 'An error occurred',
-        details: '',
-      }),
-    );
+async function fetchFile(url: string) {
+  try {
+    const response = await fetch(url, { credentials: 'same-origin' });
+    const json = await response.json();
+
+    if (response.ok) {
+      return { response: json };
+    }
+
+    throw json;
+  } catch (error) {
+    return {
+      error: error.message || 'An error occurred',
+      details: '',
+    };
+  }
 }
 
 const Activity = {

--- a/src/js/components/deployment-view/build-log.tsx
+++ b/src/js/components/deployment-view/build-log.tsx
@@ -2,7 +2,8 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 const Convert = require('ansi-to-html');
 
-import API from '../../api';
+import { Api } from '../../api/types';
+const API: Api = process.env.CHARLES ? require('../../api').default : require('../../api/static-json').default;
 import { Deployment } from '../../modules/deployments';
 import Spinner from '../common/spinner';
 


### PR DESCRIPTION
#232 broke using this project with static JSON files (i.e. started with `yarn start`) since it included the real API instead of the mock API. Fix this and also switch the mock API to use async/await instead of Promises.