### PR TITLE
Remove flash of Minard UI before deployment view

### DIFF
--- a/src/js/components/deployment-view/index.scss
+++ b/src/js/components/deployment-view/index.scss
@@ -17,3 +17,9 @@
 .dialog {
   z-index: 100;
 }
+
+.blank {
+  width: 100vw;
+  height: 100vh;
+  background-color: white;
+}

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -73,24 +73,15 @@ class DeploymentView extends React.Component<Props, void> {
       return <div className={styles.blank} />;
     }
 
-    if (isFetchError(preview)) {
-      return (
-        <div>
-          <Header />
-          <ErrorDialog
-            title="Error"
-            actionText={isUserLoggedIn ? 'Back to Minard' : undefined}
-            action={isUserLoggedIn ? this.redirectToApp : undefined}
-          >
-            <p>
-              {preview.unauthorized ? 'You do not have access to this preview.' : 'Unable to load preview.'}
-            </p>
-          </ErrorDialog>
-        </div>
-      );
-    }
+    if (!commit || isFetchError(commit) || !deployment || isFetchError(deployment) || isFetchError(preview)) {
+      let errorMessage;
 
-    if (!commit || isFetchError(commit) || !deployment || isFetchError(deployment)) {
+      if (isFetchError(preview)) {
+        errorMessage = preview.unauthorized ? 'You do not have access to this preview.' : 'Unable to load preview.';
+      } else {
+        errorMessage = 'Unable to load preview details.';
+      }
+
       return (
         <div>
           <Header />
@@ -100,7 +91,7 @@ class DeploymentView extends React.Component<Props, void> {
             action={isUserLoggedIn ? this.redirectToApp : undefined}
           >
             <p>
-              Unable to load preview details.
+              {errorMessage}
             </p>
           </ErrorDialog>
         </div>

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -11,7 +11,6 @@ import User from '../../modules/user';
 import { StateTree } from '../../reducers';
 
 import ErrorDialog from '../common/error-dialog';
-import Spinner from '../common/spinner';
 import Header from '../header';
 import BuildLog from './build-log';
 import PreviewDialog from './preview-dialog';
@@ -71,12 +70,7 @@ class DeploymentView extends React.Component<Props, void> {
     const { commit, deployment, preview, params, isUserLoggedIn, userEmail } = this.props;
 
     if (!preview) {
-      return (
-        <div>
-          <Header />
-          <Spinner />
-        </div>
-      );
+      return <div className={styles.blank} />;
     }
 
     if (isFetchError(preview)) {


### PR DESCRIPTION
When a Deployment View is used as the landing page, you get a flash of Minard's UI before the content is loaded, including possibly a "broken realtime connection" warning. Show a white page instead.

Fixes #233 