### PR TITLE
Remove email and name fields when commenting as a logged in user

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "normalize.css": "5.0.0",
     "raven-js": "^3.14.2",
     "react": "^15.5.4",
-    "react-autosize-textarea": "0.3.4",
+    "react-autosize-textarea": "^0.4.3",
     "react-dom": "^15.5.4",
     "react-flip-move": "^2.9.3",
     "react-fontawesome": "^1.6.1",

--- a/src/js/components/common/forms/comment-field.scss
+++ b/src/js/components/common/forms/comment-field.scss
@@ -18,6 +18,11 @@
     @include font-size-M;
     line-height: 22px;
     color: $minard-dark-blue;
+
+    &[disabled=disabled], &:disabled {
+      color: $minard-mid-gray;
+      background: $minard-lightest-gray;
+    }
   }
 
   textarea {

--- a/src/js/components/common/forms/comment-field.tsx
+++ b/src/js/components/common/forms/comment-field.tsx
@@ -13,38 +13,67 @@ interface ReduxFormProps {
   label: string;
   placeholder: string;
   disabled?: boolean;
+}
+
+interface PassedProps {
+  fieldRef?: (ref: HTMLElement) => void;
   onKeyDown?: (e: React.KeyboardEvent<any>) => void;
 }
 
-const Field = ({
-  input,
-  placeholder,
-  disabled,
-  type,
-  onKeyDown,
-  meta: {
-    error,
-    touched,
-  },
-}: BaseFieldProps & ReduxFormProps) => {
-  // TODO: remove the below. There currently seems to be a bug in tsc that makes it think
-  // that the variables are not used if you spread an any: https://github.com/Microsoft/TypeScript/issues/15478
-  placeholder; // tslint:disable-line
-  onKeyDown; // tslint:disable-line
-  disabled; // tslint:disable-line
+type Props = PassedProps & ReduxFormProps & BaseFieldProps;
 
-  const inputComponent = type === 'textarea' ?
-    <Textarea {...input} disabled={disabled} placeholder={placeholder} type={type} rows={3} onKeyDown={onKeyDown} /> :
-    <input {...input} disabled={disabled} placeholder={placeholder} type={type} onKeyDown={onKeyDown} />;
+class Field extends React.Component<Props, void> {
+  public render() {
+    const {
+      input,
+      placeholder,
+      disabled,
+      type,
+      onKeyDown,
+      fieldRef,
+      meta: {
+        error,
+        touched,
+      },
+    } = this.props;
 
-  return (
-    <div className={styles.field}>
-      <div>
-        {touched && error && <span className={styles.error}>{error}</span>}
+    // TODO: remove the below. There currently seems to be a bug in tsc that makes it think
+    // that the variables are not used if you spread an any: https://github.com/Microsoft/TypeScript/issues/15478
+    placeholder; // tslint:disable-line
+    onKeyDown; // tslint:disable-line
+    disabled; // tslint:disable-line
+    fieldRef; // tslint:disable-line
+
+    const inputComponent = type === 'textarea' ? (
+      <Textarea
+        {...input}
+        disabled={disabled}
+        placeholder={placeholder}
+        type={type}
+        rows={3}
+        innerRef={fieldRef}
+        onKeyDown={onKeyDown}
+      />
+    ) : (
+      <input
+        {...input}
+        disabled={disabled}
+        placeholder={placeholder}
+        type={type}
+        ref={fieldRef}
+        onKeyDown={onKeyDown}
+      />
+    );
+
+    return (
+      <div className={styles.field}>
+        <div>
+          {touched && error && <span className={styles.error}>{error}</span>}
+        </div>
+        {inputComponent}
       </div>
-      {inputComponent}
-    </div>
-  );
-};
+    );
+  }
+}
 
 export default Field;

--- a/src/js/components/common/forms/comment-field.tsx
+++ b/src/js/components/common/forms/comment-field.tsx
@@ -12,12 +12,14 @@ interface ReduxFormProps {
   type: string;
   label: string;
   placeholder: string;
+  disabled?: boolean;
   onKeyDown?: (e: React.KeyboardEvent<any>) => void;
 }
 
 const Field = ({
   input,
   placeholder,
+  disabled,
   type,
   onKeyDown,
   meta: {
@@ -26,13 +28,14 @@ const Field = ({
   },
 }: BaseFieldProps & ReduxFormProps) => {
   // TODO: remove the below. There currently seems to be a bug in tsc that makes it think
-  // that the placeholder variable is not used: https://github.com/Microsoft/TypeScript/issues/15478
+  // that the variables are not used if you spread an any: https://github.com/Microsoft/TypeScript/issues/15478
   placeholder; // tslint:disable-line
   onKeyDown; // tslint:disable-line
+  disabled; // tslint:disable-line
 
   const inputComponent = type === 'textarea' ?
-    <Textarea {...input} placeholder={placeholder} type={type} rows={3} onKeyDown={onKeyDown} /> :
-    <input {...input} placeholder={placeholder} type={type} onKeyDown={onKeyDown} />;
+    <Textarea {...input} disabled={disabled} placeholder={placeholder} type={type} rows={3} onKeyDown={onKeyDown} /> :
+    <input {...input} disabled={disabled} placeholder={placeholder} type={type} onKeyDown={onKeyDown} />;
 
   return (
     <div className={styles.field}>

--- a/src/js/components/common/forms/comment-field.tsx
+++ b/src/js/components/common/forms/comment-field.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as Textarea from 'react-autosize-textarea';
+import Textarea from 'react-autosize-textarea';
 import { BaseFieldProps, WrappedFieldMetaProps } from 'redux-form';
 
 const styles = require('./comment-field.scss');

--- a/src/js/components/common/forms/field.tsx
+++ b/src/js/components/common/forms/field.tsx
@@ -1,6 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import * as Textarea from 'react-autosize-textarea';
+import Textarea from 'react-autosize-textarea';
 import Icon = require('react-fontawesome');
 import { BaseFieldProps, WrappedFieldMetaProps } from 'redux-form';
 

--- a/src/js/components/deployment-view/new-comment-form.tsx
+++ b/src/js/components/deployment-view/new-comment-form.tsx
@@ -13,6 +13,7 @@ const styles = require('./new-comment-form.scss');
 
 interface PassedProps {
   initialValues: Partial<CreateCommentFormData>;
+  isAuthenticatedUser: boolean;
 }
 
 type Props = PassedProps & FormProps<CreateCommentFormData, PassedProps, void>;
@@ -52,7 +53,7 @@ class NewCommentForm extends React.Component<Props, void> {
   }
 
   public render() {
-    const { handleSubmit, pristine, submitting, error, invalid } = this.props;
+    const { handleSubmit, pristine, submitting, error, invalid, isAuthenticatedUser } = this.props;
 
     return (
       <div className={styles['new-comment-form']}>
@@ -63,20 +64,24 @@ class NewCommentForm extends React.Component<Props, void> {
               {error}
             </div>
           )}
-          <Field
-            name="name"
-            component={FormField}
-            type="text"
-            placeholder="Name (optional)"
-            disabled={submitting}
-          />
-          <Field
-            name="email"
-            component={FormField}
-            type="text"
-            placeholder="Email"
-            disabled={submitting}
-          />
+          {!isAuthenticatedUser && (
+            <Field
+              name="email"
+              component={FormField}
+              type="text"
+              placeholder="Email"
+              disabled={submitting}
+            />
+          )}
+          {!isAuthenticatedUser && (
+            <Field
+              name="name"
+              component={FormField}
+              type="text"
+              placeholder="Name (optional)"
+              disabled={submitting}
+            />
+          )}
           <Field
             name="message"
             component={FormField}

--- a/src/js/components/deployment-view/new-comment-form.tsx
+++ b/src/js/components/deployment-view/new-comment-form.tsx
@@ -37,10 +37,28 @@ const validate = (values: CreateCommentFormData) => {
 };
 
 class NewCommentForm extends React.Component<Props, void> {
+  private commentFieldRef: HTMLElement;
+  private focusTimeoutId: any;
+
   constructor(props: Props) {
     super(props);
 
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.storeCommentFieldRef = this.storeCommentFieldRef.bind(this);
+  }
+
+  private storeCommentFieldRef(element: HTMLElement) {
+    this.commentFieldRef = element;
+  }
+
+  public componentWillReceiveProps(nextProps: Props) {
+    if (this.props.submitting && !nextProps.submitting) {
+      this.focusTimeoutId = setTimeout(() => { this.commentFieldRef.focus(); }, 100);
+    }
+  }
+
+  public componentWillUnmount() {
+    clearTimeout(this.focusTimeoutId);
   }
 
   private handleKeyDown(e: React.KeyboardEvent<any>) {
@@ -88,6 +106,7 @@ class NewCommentForm extends React.Component<Props, void> {
             type="textarea"
             placeholder="Comment"
             disabled={submitting}
+            fieldRef={this.storeCommentFieldRef}
             onKeyDown={this.handleKeyDown}
           />
           <footer className={styles.footer}>

--- a/src/js/components/deployment-view/new-comment-form.tsx
+++ b/src/js/components/deployment-view/new-comment-form.tsx
@@ -47,8 +47,8 @@ class NewCommentForm extends React.Component<Props, void> {
     this.storeCommentFieldRef = this.storeCommentFieldRef.bind(this);
   }
 
-  private storeCommentFieldRef(element: HTMLElement) {
-    this.commentFieldRef = element;
+  public componentDidMount() {
+    this.commentFieldRef.focus();
   }
 
   public componentWillReceiveProps(nextProps: Props) {
@@ -59,6 +59,10 @@ class NewCommentForm extends React.Component<Props, void> {
 
   public componentWillUnmount() {
     clearTimeout(this.focusTimeoutId);
+  }
+
+  private storeCommentFieldRef(element: HTMLElement) {
+    this.commentFieldRef = element;
   }
 
   private handleKeyDown(e: React.KeyboardEvent<any>) {

--- a/src/js/components/deployment-view/preview-dialog.tsx
+++ b/src/js/components/deployment-view/preview-dialog.tsx
@@ -93,6 +93,7 @@ class PreviewDialog extends React.Component<Props, State> {
         )}
         {dialogOpen && (
           <NewCommentForm
+            isAuthenticatedUser={isAuthenticatedUser}
             initialValues={{
               deployment: deployment.id,
               name: getValue('commentName'),

--- a/types/react-autosize-textarea.d.ts
+++ b/types/react-autosize-textarea.d.ts
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
+interface ReactAutosizeTextareaProps extends HTMLTextAreaElement {
+  onResize?: (e: Event) => void;
+  // rows?: number;
+  maxRows?: number;
+  innerRef?: (ref: HTMLElement) => void;
+}
+
 declare class ReactAutosizeTextarea extends React.Component<ReactAutosizeTextareaProps, any> {}
 
-interface ReactAutosizeTextareaProps extends HTMLTextAreaElement {}
-
-declare var ReactAutosizeTextareaType: typeof ReactAutosizeTextarea;
-export = ReactAutosizeTextareaType;
+export default ReactAutosizeTextarea;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,13 +1805,6 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-doctrine@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
-  dependencies:
-    esutils "^1.1.6"
-    isarray "0.0.1"
-
 dom-converter@~0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
@@ -1985,10 +1978,6 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
 esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-
-esutils@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2332,10 +2321,6 @@ gaze@^1.0.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-
-get-comments@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-comments/-/get-comments-1.0.1.tgz#196759101bbbc4facf13060caaedd4870dee55be"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4524,12 +4509,12 @@ rc@~1.1.6:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-autosize-textarea@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-0.3.4.tgz#3b62fb01f48510cb18c894daefe49ffb2bd85039"
+react-autosize-textarea@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-0.4.3.tgz#71aa029a1278352dc805841fea880223cb99737a"
   dependencies:
     autosize "^3.0.15"
-    tcomb-react "^0.9.3"
+    prop-types "^15.5.6"
 
 react-deep-force-update@^1.0.0:
   version "1.0.1"
@@ -4652,7 +4637,7 @@ react-waypoint@^6.0.0:
   dependencies:
     consolidated-events "^1.0.1"
 
-react@>=0.13.0, "react@^15.3.0 || ^16.0.0", react@^15.5.4:
+"react@^15.3.0 || ^16.0.0", react@^15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
@@ -5400,32 +5385,6 @@ tar@^2.0.0, tar@~2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
-
-tcomb-doc@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/tcomb-doc/-/tcomb-doc-0.5.2.tgz#d58a653a3007e3649127864010c558a7bf666d1e"
-  dependencies:
-    tcomb "^3.0.0"
-
-tcomb-react@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/tcomb-react/-/tcomb-react-0.9.3.tgz#44713e1d2e8c2ff744b8ed6579bf77aed23b0efc"
-  dependencies:
-    doctrine "0.7.2"
-    get-comments "1.0.1"
-    react ">=0.13.0"
-    tcomb-doc "^0.5.0"
-    tcomb-validation "^3.0.0"
-
-tcomb-validation@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/tcomb-validation/-/tcomb-validation-3.3.0.tgz#29ada8534203500e90b245eedd0e1a80f1909ba2"
-  dependencies:
-    tcomb "^3.0.0"
-
-tcomb@^3.0.0:
-  version "3.2.16"
-  resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.16.tgz#345782f2f060839a2df30480209b1afc8b16e1fa"
 
 through2-filter@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This also contains a semi-related fix: the disabled state didn't work for CommentField.