### PR TITLE
Fix redirects after login

### DIFF
--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -21,7 +21,7 @@ const styles = require('./app.scss');
 type PassedProps = RouteComponentProps<{}>;
 
 interface GeneratedStateProps {
-  isUserLoggedIn: boolean;
+  hasStoredUserCredentials: boolean;
 }
 
 interface GeneratedDispatchProps {
@@ -34,9 +34,9 @@ const RedirectToTeamProjectsView = () => <Redirect to="/projects" />;
 
 class App extends React.Component<Props, void> {
   public componentWillMount() {
-    const { isUserLoggedIn, loadTeamInformation } = this.props;
+    const { hasStoredUserCredentials, loadTeamInformation } = this.props;
 
-    if (isUserLoggedIn) {
+    if (hasStoredUserCredentials) {
       // TODO: team information is now being fetched in three places:
       // - Login View after getting user login information from Auth0
       // - Signup View after getting user information (using the backend's signup endpoint)
@@ -80,7 +80,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
 });
 
 const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
-  isUserLoggedIn: User.selectors.isUserLoggedIn(state),
+  hasStoredUserCredentials: User.selectors.hasStoredUserCredentials(state),
 });
 
 export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -7,10 +7,13 @@ require('font-awesome/css/font-awesome.css');
 import './styles.scss';
 
 import { update as updateIntercom } from '../intercom';
+import Requests from '../modules/requests';
 import User from '../modules/user';
 import { StateTree } from '../reducers';
 
+import Spinner from './common/spinner';
 import DeploymentView from './deployment-view';
+import Header from './header';
 import LoginView from './login-view';
 import ProjectsFrame from './projects-frame';
 import SignupView from './signup-view';
@@ -22,6 +25,7 @@ type PassedProps = RouteComponentProps<{}>;
 
 interface GeneratedStateProps {
   hasStoredUserCredentials: boolean;
+  isLoggingIn: boolean;
 }
 
 interface GeneratedDispatchProps {
@@ -30,20 +34,54 @@ interface GeneratedDispatchProps {
 
 type Props = PassedProps & GeneratedDispatchProps & GeneratedStateProps;
 
-const RedirectToTeamProjectsView = () => <Redirect to="/projects" />;
+interface State {
+  loginTriggeredAndNotComplete: boolean;
+}
 
-class App extends React.Component<Props, void> {
-  public componentWillMount() {
-    const { hasStoredUserCredentials, loadTeamInformation } = this.props;
+const RedirectToTeamProjectsView = () => <Redirect to="/projects" />;
+const ProjectsFrameOrLogin = connect<{ isLoggedIn: boolean; }, {}, RouteComponentProps<{}>>(
+  (state) => ({ isLoggedIn: User.selectors.isUserLoggedIn(state) }),
+)(({ isLoggedIn, ...props }) => isLoggedIn ? <ProjectsFrame {...props} /> : <Redirect to="/login" />);
+const Loading = () => (
+  <div>
+    <Header />
+    <Spinner />
+  </div>
+);
+
+class App extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const { hasStoredUserCredentials, loadTeamInformation } = props;
 
     if (hasStoredUserCredentials) {
-      // TODO: team information is now being fetched in three places:
+      // NOTE: team information is fetched in three places:
       // - Login View after getting user login information from Auth0
       // - Signup View after getting user information (using the backend's signup endpoint)
       // - Here
       //
-      // We should probably try to reduce the number of places.
+      // NOTE 2: componentDidMount might be a better place to call this since if,
+      // for some reason, the component does not pass validation and is not mounted,
+      // this call will have been made for naught. On the other hand, we want to keep
+      // this component's internal state in sync with reality.
       loadTeamInformation();
+    }
+
+    this.state = {
+      // We need to store this state internally since this.props.isLoggingIn
+      // is initially false on the first render.
+      loginTriggeredAndNotComplete: props.hasStoredUserCredentials,
+    };
+  }
+
+  public componentWillReceiveProps(nextProps: Props) {
+    const { isLoggingIn } = this.props;
+    const { loginTriggeredAndNotComplete } = this.state;
+
+    if (loginTriggeredAndNotComplete && isLoggingIn && !nextProps.isLoggingIn) {
+      // Login finished
+      this.setState({ loginTriggeredAndNotComplete: false });
     }
   }
 
@@ -55,17 +93,34 @@ class App extends React.Component<Props, void> {
   }
 
   public render() {
+    const { loginTriggeredAndNotComplete } = this.state;
+
     return (
       <div id="minard-app" className={styles.app}>
         <Switch>
-          <Route path="/preview/:entityType/:id/:token" component={StreamingAPIHandler} />
-          <Route component={StreamingAPIHandler} />
+          <Route
+            path="/preview/:entityType/:id/:token"
+            component={loginTriggeredAndNotComplete ? undefined : StreamingAPIHandler}
+          />
+          <Route component={loginTriggeredAndNotComplete ? undefined : StreamingAPIHandler} />
         </Switch>
         <Switch>
-          <Route path="/project" component={ProjectsFrame} />
-          <Route path="/projects" component={ProjectsFrame} />
-          <Route path="/preview/:entityType/:id/:token/comment/:commentId" component={DeploymentView} />
-          <Route path="/preview/:entityType/:id/:token/:view?" component={DeploymentView} />
+          <Route
+            path="/project"
+            component={loginTriggeredAndNotComplete ? Loading : ProjectsFrameOrLogin}
+          />
+          <Route
+            path="/projects"
+            component={loginTriggeredAndNotComplete ? Loading : ProjectsFrameOrLogin}
+          />
+          <Route
+            path="/preview/:entityType/:id/:token/comment/:commentId"
+            component={loginTriggeredAndNotComplete ? undefined : DeploymentView}
+          />
+          <Route
+            path="/preview/:entityType/:id/:token/:view?"
+            component={loginTriggeredAndNotComplete ? undefined : DeploymentView}
+          />
           <Route path="/login/:returnPath?" component={LoginView} />
           <Route path="/signup/:teamToken?" component={SignupView} />
           <Route component={RedirectToTeamProjectsView} />
@@ -81,6 +136,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
 
 const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
   hasStoredUserCredentials: User.selectors.hasStoredUserCredentials(state),
+  isLoggingIn: Requests.selectors.isLoggingIn(state),
 });
 
 export default connect<GeneratedStateProps, GeneratedDispatchProps, PassedProps>(

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -7,7 +7,6 @@ import Commits, { Commit } from '../../modules/commits';
 import Deployments, { Deployment } from '../../modules/deployments';
 import { FetchError, isFetchError } from '../../modules/errors';
 import Previews, { EntityType, isEntityType, Preview } from '../../modules/previews';
-import Requests from '../../modules/requests';
 import User from '../../modules/user';
 import { StateTree } from '../../reducers';
 
@@ -33,7 +32,6 @@ interface GeneratedStateProps {
   commit?: Commit | FetchError;
   deployment?: Deployment | FetchError;
   isUserLoggedIn: boolean;
-  isLoggingIn: boolean;
   userEmail?: string;
 }
 
@@ -51,11 +49,10 @@ class DeploymentView extends React.Component<Props, void> {
     this.redirectToApp = this.redirectToApp.bind(this);
   }
 
-  public componentWillMount() {
+  public componentDidMount() {
     const {
       loadPreviewAndComments,
       isUserLoggedIn,
-      isLoggingIn,
       match: {
         params: {
           entityType,
@@ -70,19 +67,14 @@ class DeploymentView extends React.Component<Props, void> {
       return;
     }
 
-    if (
-      isUserLoggedIn ||
-      (!isUserLoggedIn && !isLoggingIn) // A non-Minard user viewing an open deployment
-    ) {
-      loadPreviewAndComments(id, entityType, token, isUserLoggedIn);
-    }
+    loadPreviewAndComments(id, entityType, token, isUserLoggedIn);
   }
 
   public componentWillReceiveProps(nextProps: Props) {
     const { loadPreviewAndComments, isUserLoggedIn, match: { params: { entityType, token, id } } } = nextProps;
 
     if (
-      (isUserLoggedIn && !this.props.isUserLoggedIn) || // User logged in (i.e. fetched team information) successfully
+      isUserLoggedIn !== !this.props.isUserLoggedIn || // User logged in/out
       id !== this.props.match.params.id || // Switched to another deployment
       entityType !== this.props.match.params.entityType
     ) {
@@ -187,7 +179,6 @@ const mapStateToProps = (state: StateTree, ownProps: PassedProps): GeneratedStat
     commit,
     deployment,
     isUserLoggedIn: User.selectors.isUserLoggedIn(state),
-    isLoggingIn: Requests.selectors.isLoggingIn(state),
     userEmail: User.selectors.getUserEmail(state),
   };
 };

--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -157,7 +157,7 @@ class DeploymentView extends React.Component<Props, void> {
           preview={preview}
           buildLogSelected={!showPreview}
           highlightComment={commentId}
-          isAuthenticatedUser={isUserLoggedIn}
+          isAuthenticatedUser={isUserLoggedIn} // TODO: This should check whether the preview belongs to the user's team
           userEmail={userEmail}
           linkDetails={{ entityType, id, token }}
         />

--- a/src/js/components/header.tsx
+++ b/src/js/components/header.tsx
@@ -74,9 +74,13 @@ class Header extends React.Component<Props, void> {
     if (!isUserLoggedIn) {
       return (
         <section className={styles['header-background']}>
-          <div className={classNames(styles.header, 'row', 'between-xs', 'middle-xs')}>
-            <div className={classNames(styles.logo, 'col-xs')}>
-              <h1 title="Minard" className={styles.minard}>m</h1>
+          <div className="container-fluid">
+            <div className={classNames(styles.header, 'row', 'between-l', 'middle-xs')}>
+              <div className={classNames(styles.logo, 'col-xs')}>
+                <MinardLink homepage>
+                  <img src={minardLogo} />
+                </MinardLink>
+              </div>
             </div>
           </div>
         </section>

--- a/src/js/components/login-view/index.tsx
+++ b/src/js/components/login-view/index.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 
-import { clearStoredCredentials } from '../../api/auth';
 import Requests from '../../modules/requests';
 import User, { Team } from '../../modules/user';
 import { StateTree } from '../../reducers';
@@ -55,10 +54,6 @@ class LoginView extends React.Component<Props, State> {
   }
 
   public componentDidMount() {
-    // Remove stored credentials. E.g. if there is an old access token stored that
-    // has expired.
-    clearStoredCredentials();
-
     this.lock = new Auth0Lock(process.env.AUTH0_CLIENT_ID, process.env.AUTH0_DOMAIN, {
       // oidcConformant is still in preview stage, which is why it is not documented
       // or found in the typings. Remove the `as any` below once it's included.

--- a/src/js/components/login-view/index.tsx
+++ b/src/js/components/login-view/index.tsx
@@ -6,7 +6,7 @@ import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 
 import Requests from '../../modules/requests';
-import User, { Team } from '../../modules/user';
+import User from '../../modules/user';
 import { StateTree } from '../../reducers';
 import ErrorDialog from '../common/error-dialog';
 import Spinner from '../common/spinner';
@@ -16,8 +16,8 @@ const minardLogo = require('../../../../static/minard-logo-auth0.png');
 const styles = require('./index.scss');
 
 interface GeneratedStateProps {
-  isLoadingTeamInformation: boolean;
-  team?: Team;
+  isLoggingIn: boolean;
+  isUserLoggedIn: boolean;
 }
 
 interface GeneratedDispatchProps {
@@ -127,10 +127,10 @@ class LoginView extends React.Component<Props, State> {
 
   public render() {
     const { loadingStatus } = this.state;
-    const { team, isLoadingTeamInformation } = this.props;
+    const { isUserLoggedIn, isLoggingIn } = this.props;
 
     if (loadingStatus === LoadingStatus.BACKEND) {
-      if (!team && !isLoadingTeamInformation) {
+      if (!isUserLoggedIn && !isLoggingIn) {
         return (
           <div>
             <Header />
@@ -161,8 +161,8 @@ class LoginView extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
-  isLoadingTeamInformation: Requests.selectors.isLoadingTeamInformation(state),
-  team: User.selectors.getTeam(state),
+  isLoggingIn: Requests.selectors.isLoggingIn(state),
+  isUserLoggedIn: User.selectors.isUserLoggedIn(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({

--- a/src/js/components/projects-frame.tsx
+++ b/src/js/components/projects-frame.tsx
@@ -36,6 +36,9 @@ class ProjectsFrame extends React.Component<Props, void> {
     if (team) {
       loadAllProjects(team.id);
     } else {
+      // This shouldn't happen.
+      logMessage('Inside ProjectsFrame without a team!');
+
       console.error('No team information found!');
     }
   }
@@ -56,9 +59,6 @@ class ProjectsFrame extends React.Component<Props, void> {
     const { team } = this.props;
 
     if (!team) {
-      // This shouldn't happen.
-      logMessage('Inside ProjectsFrame without a team!');
-
       return (
         <div>
           <Header />

--- a/src/js/components/projects-frame.tsx
+++ b/src/js/components/projects-frame.tsx
@@ -27,7 +27,7 @@ interface GeneratedDispatchProps {
 
 interface GeneratedStateProps {
   isUserLoggedIn: boolean;
-  isLoadingTeamInformation: boolean;
+  isLoggingIn: boolean;
   team?: Team;
 }
 
@@ -35,9 +35,9 @@ type Props = GeneratedDispatchProps & GeneratedStateProps & PassedProps;
 
 class ProjectsFrame extends React.Component<Props, void> {
   public componentWillMount() {
-    const { loadAllProjects, isUserLoggedIn, redirectToLogin, team } = this.props;
+    const { loadAllProjects, isUserLoggedIn, isLoggingIn, redirectToLogin, team } = this.props;
 
-    if (!isUserLoggedIn) {
+    if (!isUserLoggedIn && !isLoggingIn) {
       redirectToLogin();
     } else if (team) {
       loadAllProjects(team.id);
@@ -57,10 +57,10 @@ class ProjectsFrame extends React.Component<Props, void> {
   }
 
   public render() {
-    const { team, isLoadingTeamInformation } = this.props;
+    const { team, isLoggingIn } = this.props;
 
     if (!team) {
-      if (isLoadingTeamInformation) {
+      if (isLoggingIn) {
         return (
           <div>
             <Header />
@@ -104,7 +104,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => 
 
 const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
   isUserLoggedIn: User.selectors.isUserLoggedIn(state),
-  isLoadingTeamInformation: Requests.selectors.isLoadingTeamInformation(state),
+  isLoggingIn: Requests.selectors.isLoggingIn(state),
   team: User.selectors.getTeam(state),
 });
 

--- a/src/js/components/projects-frame.tsx
+++ b/src/js/components/projects-frame.tsx
@@ -3,13 +3,12 @@ import { connect, Dispatch } from 'react-redux';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 import Projects from '../modules/projects';
-import Requests from '../modules/requests';
 import User, { Team } from '../modules/user';
 import { StateTree } from '../reducers';
 
+import { logMessage } from '../logger';
 import BranchView from './branch-view';
 import ErrorDialog from './common/error-dialog';
-import Spinner from './common/spinner';
 import Footer from './footer';
 import Header from './header';
 import ProjectView from './project-view';
@@ -22,12 +21,9 @@ type PassedProps = RouteComponentProps<Params>;
 
 interface GeneratedDispatchProps {
   loadAllProjects: (teamId: string) => void;
-  redirectToLogin: () => void;
 }
 
 interface GeneratedStateProps {
-  isUserLoggedIn: boolean;
-  isLoggingIn: boolean;
   team?: Team;
 }
 
@@ -35,12 +31,12 @@ type Props = GeneratedDispatchProps & GeneratedStateProps & PassedProps;
 
 class ProjectsFrame extends React.Component<Props, void> {
   public componentWillMount() {
-    const { loadAllProjects, isUserLoggedIn, isLoggingIn, redirectToLogin, team } = this.props;
+    const { loadAllProjects, team } = this.props;
 
-    if (!isUserLoggedIn && !isLoggingIn) {
-      redirectToLogin();
-    } else if (team) {
+    if (team) {
       loadAllProjects(team.id);
+    } else {
+      console.error('No team information found!');
     }
   }
 
@@ -57,17 +53,11 @@ class ProjectsFrame extends React.Component<Props, void> {
   }
 
   public render() {
-    const { team, isLoggingIn } = this.props;
+    const { team } = this.props;
 
     if (!team) {
-      if (isLoggingIn) {
-        return (
-          <div>
-            <Header />
-            <Spinner />
-          </div>
-        );
-      }
+      // This shouldn't happen.
+      logMessage('Inside ProjectsFrame without a team!');
 
       return (
         <div>
@@ -99,12 +89,9 @@ class ProjectsFrame extends React.Component<Props, void> {
 
 const mapDispatchToProps = (dispatch: Dispatch<any>): GeneratedDispatchProps => ({
   loadAllProjects: (teamId: string) => { dispatch(Projects.actions.loadAllProjects(teamId)); },
-  redirectToLogin: () => { dispatch(User.actions.redirectToLogin()); },
 });
 
 const mapStateToProps = (state: StateTree): GeneratedStateProps => ({
-  isUserLoggedIn: User.selectors.isUserLoggedIn(state),
-  isLoggingIn: Requests.selectors.isLoggingIn(state),
   team: User.selectors.getTeam(state),
 });
 

--- a/src/js/components/streaming-api-handler.tsx
+++ b/src/js/components/streaming-api-handler.tsx
@@ -34,7 +34,7 @@ declare const EventSource: any;
 interface GeneratedStateProps {
   team?: Team;
   deployment?: Deployment | FetchError;
-  isLoadingTeamInformation: boolean;
+  isLoggingIn: boolean;
 }
 
 interface GeneratedDispatchProps {
@@ -362,22 +362,22 @@ class StreamingAPIHandler extends React.Component<Props, void> {
   }
 
   public componentWillMount() {
-    const { team, deployment, isLoadingTeamInformation } = this.props;
+    const { team, deployment, isLoggingIn } = this.props;
 
     if (streamingAPIUrl) {
       if (team) {
         this.restartConnection({ teamId: team.id });
-      } else if (!isLoadingTeamInformation && deployment && !isFetchError(deployment)) {
+      } else if (!isLoggingIn && deployment && !isFetchError(deployment)) {
         this.restartConnection({ deployment });
       }
     }
   }
 
-  public componentWillReceiveProps({ team, setConnectionState, deployment, isLoadingTeamInformation }: Props) {
+  public componentWillReceiveProps({ team, setConnectionState, deployment, isLoggingIn }: Props) {
     const {
       team: previousTeam,
       deployment: previousDeployment,
-      isLoadingTeamInformation: wasLoadingTeamInformation,
+      isLoggingIn: wasLoadingTeamInformation,
     } = this.props;
 
     if (streamingAPIUrl) {
@@ -387,7 +387,7 @@ class StreamingAPIHandler extends React.Component<Props, void> {
           this.restartConnection({ teamId: team.id });
         }
       } else if (
-        !isLoadingTeamInformation && // Only fall back to deployment-only stream if we're not logged/logging in.
+        !isLoggingIn && // Only fall back to deployment-only stream if we're not logged/logging in.
         deployment &&
         !isFetchError(deployment) &&
         (wasLoadingTeamInformation || !previousDeployment || deployment.id !== previousDeployment.id)
@@ -496,7 +496,7 @@ const mapStateToProps = (state: StateTree, ownProps: Props): GeneratedStateProps
   return {
     team: User.selectors.getTeam(state),
     deployment,
-    isLoadingTeamInformation: Requests.selectors.isLoadingTeamInformation(state),
+    isLoggingIn: Requests.selectors.isLoggingIn(state),
   };
 };
 

--- a/src/js/modules/requests/selectors.ts
+++ b/src/js/modules/requests/selectors.ts
@@ -15,6 +15,8 @@ export const isLoadingTeamInformation = createSelector<StateTree, RequestsState,
     ),
 );
 
+export const isLoggingIn = isLoadingTeamInformation;
+
 export const isLoadingAllProjects = createSelector<StateTree, RequestsState, boolean>(
   selectRequestsTree,
   (requestInformations) =>

--- a/src/js/modules/user/actions.ts
+++ b/src/js/modules/user/actions.ts
@@ -60,8 +60,9 @@ export const clearStoredData = (): ClearStoredDataAction => ({
 });
 
 export const LOAD_TEAM_INFORMATION = 'USER/LOAD_TEAM_INFORMATION';
-export const loadTeamInformation = (): LoadTeamInformationAction => ({
+export const loadTeamInformation = (redirect?: string): LoadTeamInformationAction => ({
   type: LOAD_TEAM_INFORMATION,
+  redirect,
 });
 
 export const SET_GIT_PASSWORD = 'USER/SET_GIT_PASSWORD';

--- a/src/js/modules/user/sagas.ts
+++ b/src/js/modules/user/sagas.ts
@@ -23,6 +23,8 @@ export default function createSagas(api: Api) {
   function *loadTeamInformation(action: LoadTeamInformationAction): IterableIterator<Effect> {
     const { redirect } = action;
 
+    yield put(Requests.actions.User.LoadTeamInformation.REQUEST.actionCreator());
+
     const { response, error, details, unauthorized } = yield call(api.Team.fetch);
 
     if (response) {

--- a/src/js/modules/user/sagas.ts
+++ b/src/js/modules/user/sagas.ts
@@ -20,15 +20,24 @@ import {
 import { LoadTeamInformationAction, LoginAction, RedirectToLoginAction, SignupUserAction } from './types';
 
 export default function createSagas(api: Api) {
-  // User
-  function *loadTeamInformation(_action: LoadTeamInformationAction): IterableIterator<Effect> {
-    yield put(Requests.actions.User.LoadTeamInformation.REQUEST.actionCreator());
+  function *loadTeamInformation(action: LoadTeamInformationAction): IterableIterator<Effect> {
+    const { redirect } = action;
 
     const { response, error, details, unauthorized } = yield call(api.Team.fetch);
 
     if (response) {
       const { id, name, 'invitation-token': invitationToken } = response as ApiTeam;
       yield put(setTeam(String(id), name, invitationToken));
+
+      if (redirect) {
+        // For raw deployment URLs. Cookie has been set by api.Team.fetch.
+        if (redirect.match(/^https?:\/\//)) {
+          window.location.href = redirect;
+        } else {
+          yield put(push(redirect));
+        }
+      }
+
       yield put(Requests.actions.User.LoadTeamInformation.SUCCESS.actionCreator());
 
       return true;

--- a/src/js/modules/user/selectors.ts
+++ b/src/js/modules/user/selectors.ts
@@ -6,7 +6,8 @@ import { Team, UserState } from './types';
 const selectUserTree = (state: StateTree): UserState => state.user;
 
 export const getUserEmail = (state: StateTree): string | undefined => selectUserTree(state).email;
-export const isUserLoggedIn = (state: StateTree): boolean => {
+export const isUserLoggedIn = (state: StateTree): boolean => !!selectUserTree(state).team;
+export const hasStoredUserCredentials = (state: StateTree): boolean => {
   const { email, expiresAt } = selectUserTree(state);
 
   if (!email || expiresAt === undefined) {

--- a/src/js/modules/user/types.ts
+++ b/src/js/modules/user/types.ts
@@ -53,6 +53,7 @@ export interface ClearStoredDataAction {
 
 export interface LoadTeamInformationAction {
   type: 'USER/LOAD_TEAM_INFORMATION';
+  redirect?: string;
 }
 
 export interface SetGitPasswordAction {


### PR DESCRIPTION
The react-router and team information fetching changes caused a regression: redirecting after logging in caused an infinite loop. The `componentReceivedProps` in LoginView triggered a redirect, which cause the props of LoginView to change, which triggered the redirect again, etc. React-router should have unmounted LoginView upon the redirect, but it seems that the component is now unmounted at a later stage (?).

Moved the redirect after login logic to the `loadTeamInformation` saga. Also made the following changes:
- Changed the meaning of `isUserLoggedIn`. It used to be "the user has (likely) valid credentials in localStorage". Now it's "the user has successfully fetched team information". This required the addition of a new selector to check for existing stored user credentials that the App component can use to log the user in when the app is started.
- Added an `isLoggingIn` selector and used that throughout the app to check if we're logging in. Also used `isUserLoggedIn` instead of checking for `team` in some places to make it clearer what the intent is.
- Updated the "empty" Header to the new design.
- Don't clear localStorage when opening the login page. It would make the Redux state inconsistent, and the clearing is, in any case, likely not needed.

There is one regression: there's a brief flash of the Minard main UI between logging in and seeing the Deployment View (if you're redirected). This will be fixed in a separate PR.