### PR TITLE
Hide Intercom chat launcher in Deployment View

### DIFF
--- a/src/js/components/deployment-view/index.tsx
+++ b/src/js/components/deployment-view/index.tsx
@@ -3,6 +3,7 @@ import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { push } from 'react-router-redux';
 
+import { update as updateIntercom } from '../../intercom';
 import Commits, { Commit } from '../../modules/commits';
 import Deployments, { Deployment } from '../../modules/deployments';
 import { FetchError, isFetchError } from '../../modules/errors';
@@ -68,6 +69,9 @@ class DeploymentView extends React.Component<Props, void> {
     }
 
     loadPreviewAndComments(id, entityType, token, isUserLoggedIn);
+
+    // Don't show Intercom chat launcher when previews are open
+    updateIntercom({ hide_default_launcher: true });
   }
 
   public componentWillReceiveProps(nextProps: Props) {
@@ -85,6 +89,10 @@ class DeploymentView extends React.Component<Props, void> {
 
       loadPreviewAndComments(id, entityType, token, isUserLoggedIn);
     }
+  }
+
+  public componentWillUnmount() {
+    updateIntercom({ hide_default_launcher: false });
   }
 
   private redirectToApp() {


### PR DESCRIPTION
To test:

- Set `enableIntercom: true` in webpack.config.js
- Start minard-ui with:
```shell
INTERCOM_ID=<intercom-test-app-id> yarn start -- http://localtest.me:8000
```

The chat button should be visible in all other views for (logged in) users other than Deployment View and Login/Signup View.