### PR TITLE
Default to using the local backend server in local development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,32 +37,32 @@ Set up the development environment with:
 yarn
 ```
 
-### Standalone development using the bundled JSON files
-
-```shell
-yarn start # then open http://localhost:3000/ in a browser
-```
-
 ### Development with minard-backend
 
 Install minard-backend locally or on a separate server and start
 minard-ui with:
 
 ```shell
-yarn start -- <minard-backend API URL> # then open http://localhost:3000/ in a browser
+yarn start # then open http://localhost:3000/ in a browser
 ```
 
-By default, when run locally, the minard-backend (charles) API runs
-on port 8000:
+If you are not using default settings, you can specify the location and port of
+the minard-backend server manually:
 
 ```shell
-yarn start -- http://localtest.me:8000
+CHARLES="http://location.of.server:12345" yarn start
 ```
 
 Note that in local development mode, by default, the backend sets cookies
 for the `localtest.me` domain, which should resolve to `127.0.0.1`. Because
 of this, the API URL should be set to `http://localtest.me:8000` when using
 the default settings.
+
+### Standalone development using the bundled JSON files
+
+```shell
+USE_MOCK=true yarn start # then open http://localhost:3000/ in a browser
+```
 
 ## Building for production
 
@@ -109,6 +109,7 @@ Run `yarn run` to see other available commands.
 - **AUTH0_CLIENT_ID**: The client ID for Auth0. Defaults to the client in Lucify's dev account.
 - **AUTH0_DOMAIN**: The domain used for Auth0 authentication. Defaults to Lucify's dev account domain.
 - **AUTH0_AUDIENCE**: The Auth0 audience that we're requesting. Needs to match the correct API in Auth0. Defaults to `http://localtest.me:8000`.
+- **USE_MOCK**: For development. Set this to a truthy value to use the included mock data instead of a backend server. NOTE: the mock data is out of date and might not work correctly.
 
 ## Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Minard frontend",
   "main": "index.js",
   "scripts": {
-    "start": "./start.sh",
+    "start": "npm run webpack-dev-server",
     "clean": "rm -rf dist",
     "build": "npm run clean && webpack",
     "compiled-test": "npm run clean-compile && npm run compile && cp -R json lib/ && mocha --require mock-local-storage --reporter mocha-junit-reporter lib/**/*.spec.js",

--- a/src/js/components/deployment-view/build-log.tsx
+++ b/src/js/components/deployment-view/build-log.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 const Convert = require('ansi-to-html');
 
 import { Api } from '../../api/types';
-const API: Api = process.env.CHARLES
-  ? require('../../api').default
-  : require('../../api/static-json').default;
+const API: Api = process.env.USE_MOCK
+  ? require('../../api/static-json').default
+  : require('../../api').default;
 import { Deployment } from '../../modules/deployments';
 import Spinner from '../common/spinner';
 

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-CHARLES=$1 npm run webpack-dev-server


### PR DESCRIPTION
Get rid of the need to always specify the local backend server address when starting with `yarn start`. To use the included mockup JSON files, use `USE_MOCK=true yarn start`.