### PR TITLE
Remove separate git password

### DIFF
--- a/src/js/api/types.ts
+++ b/src/js/api/types.ts
@@ -300,6 +300,5 @@ export interface ApiTeam {
 
 // User
 export interface SignupResponse {
-  password: string;
   team: ApiTeam;
 }

--- a/src/js/components/account-dialog.tsx
+++ b/src/js/components/account-dialog.tsx
@@ -135,10 +135,11 @@ class AccountDialog extends React.Component<Props, State> {
             <div className={styles.text}>
               <p>
                 Your account's email address is
-                {' '}<strong onClick={selectText}>{email}</strong>
+                {' '}<strong onClick={selectText}>{email}</strong>.
+                It is also your git username.
               </p>
               <p>
-                To change your Minard email address, please contact
+                To change your email address, please contact
                 {' '}
                 <a className={styles.url} href="mailto:support@minard.io">
                   support@minard.io
@@ -169,26 +170,6 @@ class AccountDialog extends React.Component<Props, State> {
                   Sorry, we had a problem problem requesting a password reset:
                   {' '}{error}
                 </p>}
-            </div>
-          </div>
-          <div className={styles.section}>
-            <div className={styles.label}>
-              Git credentials
-            </div>
-            <div className={styles.text}>
-              <p>
-                Your Git username is your email address:
-                {' '}<strong onClick={selectText}>{email}</strong>
-              </p>
-              <p>
-                For security reasons, your Git password was only shown when you
-                signed up for Minard. If you wish to change your password,
-                please contact
-                {' '}
-                <a className={styles.url} href="mailto:support@minard.io">
-                  support@minard.io
-                </a>.
-              </p>
             </div>
           </div>
         </div>

--- a/src/js/components/account-dialog.tsx
+++ b/src/js/components/account-dialog.tsx
@@ -139,8 +139,7 @@ class AccountDialog extends React.Component<Props, State> {
                 It is also your git username.
               </p>
               <p>
-                To change your email address, please contact
-                {' '}
+                To change your email address, please contact{' '}
                 <a className={styles.url} href="mailto:support@minard.io">
                   support@minard.io
                 </a>.

--- a/src/js/components/account-dialog.tsx
+++ b/src/js/components/account-dialog.tsx
@@ -134,8 +134,8 @@ class AccountDialog extends React.Component<Props, State> {
             </div>
             <div className={styles.text}>
               <p>
-                Your account's email address is
-                {' '}<strong onClick={selectText}>{email}</strong>.
+                Your account's email address is{' '}
+                <strong onClick={selectText}>{email}</strong>.
                 It is also your git username.
               </p>
               <p>

--- a/src/js/components/invite-team-dialog.scss
+++ b/src/js/components/invite-team-dialog.scss
@@ -19,3 +19,7 @@
   letter-spacing: -0.38px;
   line-height: 21px;
 }
+
+.mindful {
+  line-height: 1.35;
+}

--- a/src/js/components/invite-team-dialog.tsx
+++ b/src/js/components/invite-team-dialog.tsx
@@ -67,7 +67,7 @@ class InviteTeamDialog extends React.Component<Props, void> {
                       `/signup/${invitationToken}`}
                   </pre>
                 </div>
-                <p>
+                <p className={styles.mindful}>
                   <strong>Be mindful of where you share this URL!</strong>
                   {' '}Anyone can
                   join your team by using it.

--- a/src/js/components/invite-team-dialog.tsx
+++ b/src/js/components/invite-team-dialog.tsx
@@ -68,16 +68,14 @@ class InviteTeamDialog extends React.Component<Props, void> {
                   </pre>
                 </div>
                 <p className={styles.mindful}>
-                  <strong>Be mindful of where you share this URL!</strong>
-                  {' '}Anyone can
-                  join your team by using it.
+                  <strong>Be mindful of where you share this URL!</strong>{' '}
+                  Anyone can join your team by using it.
                 </p>
               </div>
             : <p>
                 It looks like the invitation URL is disabled for your team.
                 Contact <a href="mailto:support@minard.io">support@minard.io</a>
-                {' '}to
-                get it enabled.
+                {' '}to get it enabled.
               </p>}
         </div>
       </ModalDialog>

--- a/src/js/components/project-view/setup-instructions.tsx
+++ b/src/js/components/project-view/setup-instructions.tsx
@@ -41,8 +41,8 @@ const SetupInstructions = ({ project }: Props) => {
             </div>
             <div className={styles.text}>
               …Or, if you already use GitHub or another remote repository in
-              your project, add Minard
-              as a new remote and a secondary URL to origin with:
+              your project, add Minard as a new remote and a secondary URL to
+              origin with:
             </div>
             <div className={styles.code}>
               <pre>

--- a/src/js/components/project-view/setup-instructions.tsx
+++ b/src/js/components/project-view/setup-instructions.tsx
@@ -42,7 +42,7 @@ const SetupInstructions = ({ project }: Props) => {
             <div className={styles.text}>
               …Or, if you already use GitHub or another remote repository in
               your project, add Minard
-              as a new remote and secodary URL to origin with:
+              as a new remote and a secondary URL to origin with:
             </div>
             <div className={styles.code}>
               <pre>

--- a/src/js/components/signup-view/index.tsx
+++ b/src/js/components/signup-view/index.tsx
@@ -3,7 +3,6 @@ import * as moment from 'moment';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
-import { push } from 'react-router-redux';
 
 import Errors from '../../modules/errors';
 import User from '../../modules/user';
@@ -13,7 +12,6 @@ import Spinner from '../common/spinner';
 import Header from '../header';
 
 interface GeneratedDispatchProps {
-  navigateTo: (url: string) => void;
   signupUser: (
     email: string,
     idToken: string,
@@ -23,7 +21,6 @@ interface GeneratedDispatchProps {
 }
 
 interface GeneratedStateProps {
-  password?: string;
   email?: string;
   error?: string;
 }
@@ -51,12 +48,9 @@ class SignupView extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-
     this.state = {
       loadingStatus: LoadingStatus.AUTH0,
     };
-
-    this.redirectToApp = this.redirectToApp.bind(this);
   }
 
   public componentWillMount() {
@@ -133,12 +127,8 @@ class SignupView extends React.Component<Props, State> {
     }
   }
 
-  private redirectToApp() {
-    this.props.navigateTo('/');
-  }
-
   public render() {
-    const { password, email, error } = this.props;
+    const { error } = this.props;
     const { loadingStatus, auth0Error } = this.state;
 
     if (auth0Error || error) {
@@ -151,47 +141,6 @@ class SignupView extends React.Component<Props, State> {
             <p>
               Please try signing up again. If that doesn't work, contact
               {' '}<a href="mailto:support@minard.io">support@minard.io</a>.
-            </p>
-          </ErrorDialog>
-        </div>
-      );
-    }
-
-    if (password) {
-      return (
-        <div>
-          <Header />
-          <ErrorDialog
-            title="Important"
-            actionText="Continue to Minard"
-            action={this.redirectToApp}
-          >
-            <p>
-              Success! Your Minard user account has been created. To push code
-              to Minard, you will need to use the following Git username and
-              password.
-            </p>
-            <p>
-              <strong>
-                Please store the password in some place safe. This is the only
-                time you will see this password. If you ever lose it, send a
-                message to
-                {' '}<a href="mailto:support@minard.io">support@minard.io</a> to
-                have it reset.
-              </strong>
-            </p>
-            <p>
-              <strong>Username:</strong>
-              <br />
-              <code>{email}</code>
-            </p>
-            <p>
-              <strong>Password:</strong>
-              <br />
-              <code>{password}</code>
-            </p>
-            <p>
-              Once you have stored this information, continue on to Minard.
             </p>
           </ErrorDialog>
         </div>
@@ -213,9 +162,7 @@ class SignupView extends React.Component<Props, State> {
 
 const mapStateToProps = (state: StateTree): GeneratedStateProps => {
   const error = Errors.selectors.getSignupError(state);
-
   return {
-    password: User.selectors.getUserGitPassword(state),
     email: User.selectors.getUserEmail(state),
     error: error && error.error,
   };
@@ -231,9 +178,6 @@ const mapDispatchToProps = (
     expiresAt: number,
   ) => {
     dispatch(User.actions.signupUser(email, idToken, accessToken, expiresAt));
-  },
-  navigateTo: (url: string) => {
-    dispatch(push(url));
   },
 });
 

--- a/src/js/components/signup-view/index.tsx
+++ b/src/js/components/signup-view/index.tsx
@@ -66,12 +66,17 @@ class SignupView extends React.Component<Props, State> {
     });
 
     if (teamToken) {
+      // This is loaded initially when the user arrives at the page
       this.setState({ auth0Error: undefined });
       this.auth0.authorize({
         connection: 'Username-Password-Authentication',
         team_token: teamToken,
       });
     } else {
+      // Once the user has signed up at Auth0, they are returned to this page
+      // with a hash in the URL. This function parses that hash and initiates
+      // the signup with the Minard backend. The team token is included in the
+      // JWT.
       this.auth0.parseHash({}, (auth0Error: Auth0Error, data: any) => {
         if (auth0Error) {
           console.error('Unable to sign up', auth0Error);
@@ -101,9 +106,10 @@ class SignupView extends React.Component<Props, State> {
                     .add(expiresIn, 'seconds')
                     .valueOf();
 
-                  // Will use the teamToken in the accessToken to add the user to the
-                  // appropriate team and return the user's git password which is then
-                  // stored to the Redux state
+                  // Will use the teamToken in the accessToken to add the user
+                  // to the appropriate team. The signup saga will store the
+                  // team ID into the Redux state and redirect the user into
+                  // the app.
                   signupUser(email, idToken, accessToken, expiresAt);
 
                   this.setState({ loadingStatus: LoadingStatus.BACKEND });
@@ -139,8 +145,8 @@ class SignupView extends React.Component<Props, State> {
           <ErrorDialog title="Something went wrong">
             <p>{auth0Error || error}</p>
             <p>
-              Please try signing up again. If that doesn't work, contact
-              {' '}<a href="mailto:support@minard.io">support@minard.io</a>.
+              Please try signing up again. If that doesn't work, contact{' '}
+              <a href="mailto:support@minard.io">support@minard.io</a>.
             </p>
           </ErrorDialog>
         </div>

--- a/src/js/modules/user/actions.ts
+++ b/src/js/modules/user/actions.ts
@@ -4,7 +4,6 @@ import {
   LoginAction,
   LogoutAction,
   RedirectToLoginAction,
-  SetGitPasswordAction,
   SetTeamAction,
   SetUserEmailAction,
   SignupUserAction,
@@ -77,12 +76,6 @@ export const loadTeamInformation = (
 ): LoadTeamInformationAction => ({
   type: LOAD_TEAM_INFORMATION,
   redirect,
-});
-
-export const SET_GIT_PASSWORD = 'USER/SET_GIT_PASSWORD';
-export const setGitPassword = (password: string): SetGitPasswordAction => ({
-  type: SET_GIT_PASSWORD,
-  password,
 });
 
 export const REDIRECT_TO_LOGIN = 'USER/REDIRECT_TO_LOGIN';

--- a/src/js/modules/user/reducer.spec.ts
+++ b/src/js/modules/user/reducer.spec.ts
@@ -1,10 +1,5 @@
 import { expect } from 'chai';
-import {
-  clearStoredData,
-  setGitPassword,
-  setTeam,
-  setUserEmail,
-} from './actions';
+import { clearStoredData, setTeam, setUserEmail } from './actions';
 import reducer from './reducer';
 import { UserState } from './types';
 
@@ -17,7 +12,6 @@ describe('User reducer', () => {
       name: 'team name',
       invitationToken: 'testtoken',
     },
-    gitPassword: 'secretpassword',
   };
 
   const initialState: UserState = {};
@@ -42,22 +36,6 @@ describe('User reducer', () => {
         stateWithUser.email!,
         stateWithUser.expiresAt!,
       );
-      const newState = reducer(stateWithUser, action);
-      expect(newState).to.deep.equal(stateWithUser);
-      expect(newState).to.equal(stateWithUser);
-    });
-  });
-
-  describe('setGitPassword', () => {
-    it('should update if the password changes', () => {
-      const action = setGitPassword('newPassword');
-      const newState = reducer(initialState, action);
-      expect(newState.gitPassword).to.equal(action.password);
-      expect(newState).to.not.equal(initialState);
-    });
-
-    it('should do nothing if nothing changes', () => {
-      const action = setGitPassword(stateWithUser.gitPassword!);
       const newState = reducer(stateWithUser, action);
       expect(newState).to.deep.equal(stateWithUser);
       expect(newState).to.equal(stateWithUser);

--- a/src/js/modules/user/reducer.ts
+++ b/src/js/modules/user/reducer.ts
@@ -1,17 +1,7 @@
 import { getEmail, getExpirationTime } from '../../api/auth';
 import { login as intercomLogin } from '../../intercom';
-import {
-  CLEAR_STORED_DATA,
-  SET_GIT_PASSWORD,
-  SET_TEAM,
-  SET_USER_EMAIL,
-} from './actions';
-import {
-  SetGitPasswordAction,
-  SetTeamAction,
-  SetUserEmailAction,
-  UserState,
-} from './types';
+import { CLEAR_STORED_DATA, SET_TEAM, SET_USER_EMAIL } from './actions';
+import { SetTeamAction, SetUserEmailAction, UserState } from './types';
 
 // TODO: Move Intercom stuff elsewhere?
 const existingUserEmail = getEmail();
@@ -59,18 +49,8 @@ const reducer = (state: UserState = initialState, action: any): UserState => {
           },
         };
       }
-
       return state;
-    case SET_GIT_PASSWORD:
-      const { password } = action as SetGitPasswordAction;
-      if (state.gitPassword !== password) {
-        return {
-          ...state,
-          gitPassword: password,
-        };
-      }
 
-      return state;
     case CLEAR_STORED_DATA:
       return {};
     default:

--- a/src/js/modules/user/sagas.ts
+++ b/src/js/modules/user/sagas.ts
@@ -15,7 +15,6 @@ import {
   LOGIN,
   LOGOUT,
   REDIRECT_TO_LOGIN,
-  setGitPassword,
   setTeam,
   setUserEmail,
   SIGNUP_USER,
@@ -84,10 +83,9 @@ export default function createSagas(api: Api) {
     const { response, error, details } = yield call(api.User.signup);
 
     if (response) {
-      const { password, team: { id, name } } = response as SignupResponse;
+      const { team: { id, name } } = response as SignupResponse;
       yield put(setTeam(String(id), name));
-      yield put(setGitPassword(password));
-
+      yield put(push('/'));
       return true;
     } else {
       console.error('signupUser error', error, details);

--- a/src/js/modules/user/selectors.ts
+++ b/src/js/modules/user/selectors.ts
@@ -22,5 +22,3 @@ export const hasStoredUserCredentials = (state: StateTree): boolean => {
 };
 export const getTeam = (state: StateTree): Team | undefined =>
   selectUserTree(state).team;
-export const getUserGitPassword = (state: StateTree): string | undefined =>
-  selectUserTree(state).gitPassword;

--- a/src/js/modules/user/types.ts
+++ b/src/js/modules/user/types.ts
@@ -2,7 +2,6 @@
 export interface UserState {
   email?: string;
   team?: Team;
-  gitPassword?: string;
   expiresAt?: number; // moment.valueOf()
   // TODO: add full name
 }
@@ -54,11 +53,6 @@ export interface ClearStoredDataAction {
 export interface LoadTeamInformationAction {
   type: 'USER/LOAD_TEAM_INFORMATION';
   redirect?: string;
-}
-
-export interface SetGitPasswordAction {
-  type: 'USER/SET_GIT_PASSWORD';
-  password: string;
 }
 
 export interface RedirectToLoginAction {


### PR DESCRIPTION
Update the UI to reflect the fact that there is no more a separate git password.

This change affects the account modal, and removes the welcome modal that showed up after signup.

Test by signing up and checking the account modal afterwards.
